### PR TITLE
Fixing TypeInitialization and TypeInvocation exceptions 

### DIFF
--- a/ApprovalUtilities.Tests/Utilities/PathUtilitiesTest.cs
+++ b/ApprovalUtilities.Tests/Utilities/PathUtilitiesTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.IO;
 using ApprovalTests;
 using ApprovalUtilities.Utilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -8,6 +9,27 @@ namespace ApprovalUtilities.Tests.Utilities
 	[TestClass]
 	public class PathUtilitiesTest
 	{
+
+        /// <summary>
+        /// where.exe does not ship with Windows XP SP3, which some people are still being forced to use. This
+        /// causes the <see cref="PathUtilities.LocateFileFromEnviormentPath"/> method to return a null, which 
+        /// in turn causes the init of GenericDiffReporter to throw a TypeInitialization exception, followed by a 
+        /// TargetInvocation exception. One can download the 'where.exe' from the internet, but it 
+        /// would IMO be easier to just fail a test, report the problem, and not break the developer's flow.
+        /// In addition, returning a string[] from the  <see cref="PathUtilities.LocateFileFromEnviormentPath"/>
+        /// will stop the exception from being thrown, and will allow the developer to continue (provided they've installed
+        /// their difftool to a default path). If their tool never loads for them, they'll find themselves inside this source
+        /// code pretty quickly, and discover the problem that way. The TypeInit and TypeInvoke exceptions do not give one
+        /// a single clue as to what the problem is especially when they are being thrown from inside the DLL from the nuget package.
+        /// </summary>
+        [TestMethod]
+        public void TestDoesWhereExeExist()
+        {
+            bool doesWhereExist = File.Exists(@"C:\Windows\System32\where.exe") || File.Exists(@"C:\Windows\SysWOW64\where.exe");
+            Assert.IsTrue(doesWhereExist, "'where.exe' does not exist, automated searching for your diff tool will not work");
+        }
+
+
 		[TestMethod]
 		public void ScrubPathTest()
 		{
@@ -36,5 +58,6 @@ namespace ApprovalUtilities.Tests.Utilities
 			var results = PathUtilities.LocateFileFromEnviormentPath(noneExistingFile);
 			Assert.AreEqual(0,results.Count());
 		}
+
 	}
 }

--- a/ApprovalUtilities/Utilities/PathUtilities.cs
+++ b/ApprovalUtilities/Utilities/PathUtilities.cs
@@ -39,7 +39,8 @@ namespace ApprovalUtilities.Utilities
 			string processName = @"C:\Windows\System32\where.exe";
 			if (!File.Exists(processName))
 			{
-				return null;
+                // report the actual error so the developer can do something about it. And no more TypeInit & TypeInvoke exceptions :)
+                return new string[] { "'where.exe' does not exist, automated searching for your diff tool will not work" };
 			}
 			return
 				GetOutputFromProcess(processName, toFind).Split('\n').Select(s => s.Trim()).Where(s => !string.IsNullOrEmpty(s)).


### PR DESCRIPTION
Thrown when 'where.exe' doesn't exist.

The program 'where.exe' does not ship with Windows XP SP3, which some people are still being forced to use. This causes the `PathUtilities.LocateFileFromEnviormentPath` method to return a null, which 
in turn causes the init of `GenericDiffReporter` to throw a `TypeInitialization` exception, followed by a 
`TargetInvocation` exception. 

One can download the 'where.exe' from the internet, but it would IMO be easier to just fail a test, report the problem, and not break the developer's flow.In addition, returning a `string[]` from the  `PathUtilities.LocateFileFromEnviormentPath"` will stop the exception from being thrown, and will allow the developer to continue (provided they've installed their difftool to a default path). If their tool never loads for them, they'll find themselves inside the source code pretty quickly, and discover the problem that way. At the moment, the TypeInit and TypeInvoke exceptions do not give a single clue as to what the problem is especially when they are being thrown from inside the DLL from the NuGet package.
