### PR TITLE
Improve CruiseControlNetReporter detection logic

### DIFF
--- a/ApprovalTests/Reporters/CruiseControlNetReporter.cs
+++ b/ApprovalTests/Reporters/CruiseControlNetReporter.cs
@@ -14,7 +14,7 @@ namespace ApprovalTests.Reporters
 
 		public bool IsWorkingInThisEnvironment(string forFile)
 		{
-            return Environment.GetEnvironmentVariables().Contains("CCNetBuildDate");
+            return Environment.GetEnvironmentVariable("CCNetBuildDate") != null;
 		}
 	}
 }


### PR DESCRIPTION
After reviewing the CruiseControl.NET source code it seems possible that in some situations the CCNetLabel could end up being null or blank. Null IntegrationProperties are not passed along to NAnt. Changing the environment detector logic to use CCNetBuildDate environment variable which is based on build StartDate which is always present and never null.
