### PR TITLE
View .sql files in diff reporter

### DIFF
--- a/ApprovalTests/Reporters/GenericDiffReporter.cs
+++ b/ApprovalTests/Reporters/GenericDiffReporter.cs
@@ -12,8 +12,7 @@ namespace ApprovalTests.Reporters
 	{
 		public const string DEFAULT_ARGUMENT_FORMAT = "\"{0}\" \"{1}\"";
 
-		public static readonly string[] TEXT_FILE_TYPES = new[]
-			{".txt", ".csv", ".htm", ".html", ".xml", ".eml", ".cs", ".css"};
+		public static readonly string[] TEXT_FILE_TYPES = {".txt", ".csv", ".htm", ".html", ".xml", ".eml", ".cs", ".css", ".sql"};
 
 		public static readonly string[] IMAGE_FILE_TYPES = {".png", ".gif", ".jpg", ".jpeg", ".bmp", ".tif", ".tiff"};
 


### PR DESCRIPTION
I would like to name some of my approval files with an .sql extension so I
can quickly open them in sql tools but still want to use the diff
reporter.
