### PR TITLE
Using Where.exe causes Build scripts using Gallio to fail.

### DIFF
--- a/ApprovalUtilities/Utilities/PathUtilities.cs
+++ b/ApprovalUtilities/Utilities/PathUtilities.cs
@@ -1,7 +1,8 @@
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Text;
 
 namespace ApprovalUtilities.Utilities
 {
@@ -34,40 +35,17 @@ namespace ApprovalUtilities.Utilities
 			return GetDirectoryForCaller(1) + fileName;
 		}
 
-		public static string[] LocateFileFromEnviormentPath(string toFind)
+		public static IEnumerable<string> LocateFileFromEnviormentPath(string toFind)
 		{
-			string processName = @"C:\Windows\System32\where.exe";
-			if (!File.Exists(processName))
+			var results = new List<string>();
+			if (File.Exists(toFind))
 			{
-				return null;
+				results.Add(Path.GetFullPath(toFind));
 			}
-			return
-				GetOutputFromProcess(processName, toFind).Split('\n').Select(s => s.Trim()).Where(s => !string.IsNullOrEmpty(s)).
-					ToArray();
-		}
 
-		public static string GetOutputFromProcess(string processName, string arguments)
-		{
-			ProcessStartInfo processStartInfo = new ProcessStartInfo
-				{
-					CreateNoWindow = true,
-					RedirectStandardOutput = true,
-					RedirectStandardInput = true,
-					UseShellExecute = false,
-					Arguments = arguments,
-					FileName = processName
-				};
-
-			StringBuilder outputBuilder = new StringBuilder();
-			Process process = new Process {StartInfo = processStartInfo, EnableRaisingEvents = true};
-			process.OutputDataReceived += (sender, e) => outputBuilder.AppendLine(e.Data);
-			process.Start();
-			process.BeginOutputReadLine();
-			process.WaitForExit();
-			process.CancelOutputRead();
-
-			// use the output
-			return outputBuilder.ToString();
+			var values = Environment.GetEnvironmentVariable("PATH");
+			results.AddRange(values.Split(';').Select(path => Path.Combine(path, toFind)).Where(File.Exists));
+			return results.ToArray();
 		}
 	}
 }


### PR DESCRIPTION
We use TFS and Gallio in our build scripts.  Recently, I added some tests using Approval Tests to my code base. The build script started breaking with the following message repeated 7 times.

[ERROR] INFO: Could not find files for the given pattern(s)

I used SysInternals' ProcMon to track the issue down and found that the ApprovalTests were looking for 7 different diff tools that I didn't have.  That correlated with the 7 repeats.  I also found in my investigations that the only program that displayed that exact error message was the 'where.exe' utility.

I tracked that down to the included file and rewrote the process to use a much simpler path search that doesn't throw any extraneous errors.

This patch fixed my build breakage as well.
