### PR TITLE
Concurrency issue for the parser collection in StackTraceParser

### DIFF
--- a/ApprovalTests.Tests/ApprovalTests.Tests.csproj
+++ b/ApprovalTests.Tests/ApprovalTests.Tests.csproj
@@ -136,6 +136,7 @@
     <Compile Include="NHibernate\Job.cs" />
     <Compile Include="NHibernate\NHibernateTest.cs" />
     <Compile Include="Pdf\PdfTest.cs" />
+    <Compile Include="StackTraceParsers\StackTraceParserTests.cs" />
     <Compile Include="StringEncodingTest.cs" />
     <Compile Include="WinForms\DemoForm.cs">
       <SubType>Form</SubType>
@@ -220,7 +221,6 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="obj\" />
-    <Folder Include="StackTraceParsers\" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
@@ -241,6 +241,7 @@
   </ItemGroup>
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />

--- a/ApprovalTests.Tests/StackTraceParsers/StackTraceParserTests.cs
+++ b/ApprovalTests.Tests/StackTraceParsers/StackTraceParserTests.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ApprovalTests.StackTraceParsers;
+using AssertExLib;
+using NUnit.Framework;
+
+namespace ApprovalTests.Tests.StackTraceParsers
+{
+    [TestFixture]
+    public class StackTraceParserTests
+    {
+        // This test is not perfect, even if the StackTraceParser parser collection is thread-safe it is possible that the test
+        // pass. The bug is the result on concurrency between two threads, so this is a timing issue, sometime it happens sometime not.
+        [Test]
+        public void Parse_UsingStaticInitialize_DontThrowInvalidOperationException()
+        {
+            // ARRANGE
+            var parser = new StackTraceParser();
+
+            // ACT + ASSERT
+            try
+            {
+                Parallel.ForEach(Enumerable.Range(1, 20), (_) =>
+                {
+                    try
+                    {
+                        var stackTrace = new StackTrace();
+                        parser.Parse(stackTrace);
+                    }
+                    catch (InvalidOperationException e)
+                    {
+                        Assert.Fail(
+                            "InvalidOperationException when trying to parse stacktrace. " +
+                                "This is caused by the parser collection not being thread-safe. " +
+                                    "Original exception message : {0} and stacktrace : {1}", 
+                                e.Message, 
+                                e.StackTrace
+                            );
+                    }
+                    // Because the current stacktrace passed to the parse method doesn't contains any trace of a compliant stacktrace parser
+                    // it's normal that we receive an exception here so let's ignore it.
+                    catch (Exception e)
+                    {
+                        if (!e.Message.StartsWith("Approvals is not set up to use your test framework", StringComparison.OrdinalIgnoreCase))
+                        {
+                            Assert.Fail("Any other exception");
+                        }
+                    }
+                });
+            }
+            catch (AggregateException e)
+            {
+                // Throw the first inner exception of the AggretateException, this way NUnit shows a much clearer result.
+                throw e.InnerException;
+            }
+        }
+    }
+}

--- a/ApprovalTests/StackTraceParsers/StackTraceParser.cs
+++ b/ApprovalTests/StackTraceParsers/StackTraceParser.cs
@@ -11,6 +11,11 @@ namespace ApprovalTests.StackTraceParsers
 		private static readonly IList<IStackTraceParser> parsers = new List<IStackTraceParser>();
 		private IStackTraceParser parser;
 
+        static StackTraceParser()
+        {
+            GetParsers();
+        }
+
 		public string ForTestingFramework
 		{
 			get { return GetParsers().Select(x => x.ForTestingFramework).ToReadableString(); }
@@ -65,17 +70,18 @@ namespace ApprovalTests.StackTraceParsers
 		{
 			parsers.Add(parser);
 		}
+
 		public static IEnumerable<IStackTraceParser> GetParsers()
 		{
-			if (parsers.Count == 0)
-			{
-				LoadIfApplicable(parsers, new NUnitStackTraceParser());
-				LoadIfApplicable(parsers, new VSStackTraceParser());
-				LoadIfApplicable(parsers, new MbUnitStackTraceParser());
-				LoadIfApplicable(parsers,new XUnitStackTraceParser());
-				LoadIfApplicable(parsers,new XUnitTheoryStackTraceParser());
-				parsers.Add(new MSpecStackTraceParser());
-			}
+            if (parsers.Count == 0)
+            {
+                LoadIfApplicable(parsers, new NUnitStackTraceParser());
+                LoadIfApplicable(parsers, new VSStackTraceParser());
+                LoadIfApplicable(parsers, new MbUnitStackTraceParser());
+                LoadIfApplicable(parsers, new XUnitStackTraceParser());
+                LoadIfApplicable(parsers, new XUnitTheoryStackTraceParser());
+                parsers.Add(new MSpecStackTraceParser());
+            }
 			return parsers;
 		}
 	}


### PR DESCRIPTION
By using Approvals in MbUnit and by executing tests in parallel I discovered an issue in StackTraceParser that the initialization of the parsers collection is not thread-safe. I fixed the issue by using a static constructor, this way we ensure that the collection initialization is thread-safe.

![image](https://f.cloud.github.com/assets/2493565/1684262/f3912a4a-5dc8-11e3-93a3-9e3b179745a0.png)

I've also added a unit test.
