### PR TITLE
Fixes #78 - GenericDiffReporter now creates image files in stead of text...

### DIFF
--- a/ApprovalTests.Tests/ApprovalTests.Tests.csproj
+++ b/ApprovalTests.Tests/ApprovalTests.Tests.csproj
@@ -73,6 +73,7 @@
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.Entity" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Mvc, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
@@ -92,6 +93,7 @@
     <Compile Include="CleanupReporter.cs" />
     <Compile Include="Core\Exceptions\SerializableExceptionsTest.cs" />
     <Compile Include="Namer\StackTraceParsers\Class1.cs" />
+    <Compile Include="Reporters\P4MergeReporterTest.cs" />
     <Compile Include="RunMaintenance.cs" />
     <Compile Include="Email\EmailTest.cs" />
     <Compile Include="EntityFramework\CompanyList.cs" />

--- a/ApprovalTests.Tests/Reporters/P4MergeReporterTest.cs
+++ b/ApprovalTests.Tests/Reporters/P4MergeReporterTest.cs
@@ -1,0 +1,33 @@
+﻿using System.Drawing;
+using System.IO;
+using System.Reflection;
+using ApprovalTests.Core.Exceptions;
+using ApprovalTests.Reporters;
+using ApprovalUtilities.Utilities;
+using NUnit.Framework;
+
+namespace ApprovalTests.Tests.Reporters
+{
+    [TestFixture]
+    public class P4MergeReporterTest
+    {
+        public string GetBitmapFilePath()
+        {
+            var bitmapFile = Path.GetTempFileName().Replace("tmp", "png");
+            using (var bitmap = new Bitmap(1, 1))
+            {
+                bitmap.Save(bitmapFile);
+            }
+            return bitmapFile;
+        }
+
+        [Test]
+        [UseReporter(typeof(QuietReporter))]
+        public void P4MergeLaunchesOnFirstTestRun()
+        {
+            var existingDefaultApprovalFileName = PathUtilities.GetDirectoryForCaller() + GetType().Name + "." + MethodBase.GetCurrentMethod().Name + "approved.png";
+            File.Delete(existingDefaultApprovalFileName);
+            Assert.Throws<ApprovalMissingException>(() => Approvals.VerifyFile(GetBitmapFilePath()));
+        }
+    }
+}

--- a/ApprovalTests/Reporters/GenericDiffReporter.cs
+++ b/ApprovalTests/Reporters/GenericDiffReporter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -140,7 +141,18 @@ Recieved {0} ({1}, {2}, {3})"
 		{
 			if (!File.Exists(approved))
 			{
-				File.WriteAllText(approved, " ", Encoding.UTF8);
+                var extension = "." + approved.Split('.').Last();
+                if (IMAGE_FILE_TYPES.Contains(extension))
+                {
+                    using (var bitmap = new Bitmap(1, 1))
+                    {
+                        bitmap.Save(approved);
+                    }
+                }
+                else
+                {
+                    File.Create(approved).Dispose();
+                }
 				ReporterEvents.CreatedApprovedFile(approved);
 			}
 		}


### PR DESCRIPTION
... files if the diff involves images.
