### PR TITLE
ensuring Consistent DPI fo the image in file - otherwise DPI will depend...

### DIFF
--- a/ApprovalTests/Reporters/GenericDiffReporter.cs
+++ b/ApprovalTests/Reporters/GenericDiffReporter.cs
@@ -146,6 +146,7 @@ Recieved {0} ({1}, {2}, {3})"
 				{
 					using (var bitmap = new Bitmap(1, 1))
 					{
+                        bitmap.SetResolution(96, 96);
 						bitmap.Save(approved);
 					}
 				}


### PR DESCRIPTION
... on environment.

It doesn't feel quite right, but I think `EnsureFileExists` may need be a bit more intelligent as to which type of file to create (and in this case also which properties of the file type should be included). 
Maybe the specific DiffReporters should actually make that choice in stead of the generic one. 
