### PR TITLE
Create more robust parent-process walking code.

### DIFF
--- a/ApprovalTests/ApprovalTests.csproj
+++ b/ApprovalTests/ApprovalTests.csproj
@@ -215,6 +215,7 @@
     <Compile Include="Namers\UnitTestFrameworks\MbUnitStackTraceParser.cs" />
     <Compile Include="Namers\UnitTestFrameworks\VSStackTraceParser.cs" />
     <Compile Include="Reporters\UseReporterAttribute.cs" />
+    <Compile Include="Utilities\ParentProcessUtils.cs" />
     <Compile Include="Utilities\StackTraceScrubber.cs" />
     <Compile Include="StatePrinter\StatePrinterApprovals.cs" />
     <Compile Include="TheoryTests\SerializableTheory.cs" />

--- a/ApprovalTests/Reporters/TfsReporter.cs
+++ b/ApprovalTests/Reporters/TfsReporter.cs
@@ -1,4 +1,6 @@
-﻿namespace ApprovalTests.Reporters
+﻿using ApprovalTests.Utilities;
+
+namespace ApprovalTests.Reporters
 {
     using System;
     using System.Diagnostics;
@@ -19,23 +21,9 @@
             // does nothing
         }
 
-        // TODO: This belongs in a utility class
-        private static Process GetParentProcess(Process currentProcess)
-        {
-            try
-            {
-                var pc = new PerformanceCounter("Process", "Creating Process Id", currentProcess.ProcessName);
-                return Process.GetProcessById((int)pc.RawValue);
-            }
-            catch (ArgumentException)
-            {
-                return null;
-            }
-        }
-
         private static string GetParentProcessName()
         {
-            var parentProcess = GetParentProcess(Process.GetCurrentProcess());
+            var parentProcess = ParentProcessUtils.GetParentProcess(Process.GetCurrentProcess());
             return parentProcess == null ? string.Empty : parentProcess.ProcessName;
         }
     }

--- a/ApprovalTests/Reporters/VisualStudioReporter.cs
+++ b/ApprovalTests/Reporters/VisualStudioReporter.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using ApprovalTests.Utilities;
 
 namespace ApprovalTests.Reporters
 {
@@ -25,37 +26,12 @@ namespace ApprovalTests.Reporters
             return base.IsWorkingInThisEnvironment(forFile) && LaunchedFromVisualStudio();
         }
 
-        private static Process GetParentProcess(Process currentProcess)
-        {
-            try
-            {
-                var pc = new PerformanceCounter("Process", "Creating Process Id", currentProcess.ProcessName);
-                return Process.GetProcessById((int)pc.RawValue);
-            }
-            catch (ArgumentException)
-            {
-                return null;
-            }
-        }
-
         private static string GetPath()
         {
             LaunchedFromVisualStudio();
             return PATH ?? "Not launched from Visual Studio.";
         }
 
-        private static IEnumerable<Process> GetProcessAndParent()
-        {
-            var currentProcess = Process.GetCurrentProcess();
-            yield return currentProcess;
-            var parentProcess = GetParentProcess(currentProcess);
-            do
-            {
-                yield return parentProcess;
-                parentProcess = GetParentProcess(parentProcess);
-            }
-            while (parentProcess != null);
-        }
 
         private static bool LaunchedFromVisualStudio()
         {
@@ -64,7 +40,7 @@ namespace ApprovalTests.Reporters
                 return true;
             }
 
-            var processAndParent = GetProcessAndParent().ToArray();
+            var processAndParent = ParentProcessUtils.CurrentProcessWithAncestors().ToArray();
 
             Process process = null;
 

--- a/ApprovalTests/Utilities/ParentProcessUtils.cs
+++ b/ApprovalTests/Utilities/ParentProcessUtils.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+
+namespace ApprovalTests.Utilities
+{
+	static class ParentProcessUtils
+	{
+		public static Process GetParentProcess(Process currentProcess)
+		{
+			try
+			{
+				var pc = new PerformanceCounter("Process", "Creating Process Id", currentProcess.ProcessName);
+				using (pc)
+					return Process.GetProcessById((int)pc.RawValue);
+			}
+			catch (ArgumentException)
+			{
+				return null;
+			}
+		}
+
+		public static IEnumerable<Process> CurrentProcessWithAncestors()
+		{
+			return GetSelfAndAncestors(Process.GetCurrentProcess());
+		}
+
+		public static IEnumerable<Process> GetSelfAndAncestors(Process process)
+		{
+			while (process != null)
+			{
+				yield return process;
+				process = GetParentProcess(process);
+			}
+		}
+	}
+}


### PR DESCRIPTION
This fixes a NullReferenceException that occurs when the current process has no (accessible) parent process.

Also, it's shorter, and the implementation is reused in the Tfs and VisualStudio reporters.

The NRE is currently problematic for me as it's making using nunit's GUI on my machine impossible (loading test cases aborts with an exception in the VisualStudioReporter).
