### PR TITLE
Spelling mistake

### DIFF
--- a/ApprovalTests/Namers/StackTraceParsers/StackTraceParser.cs
+++ b/ApprovalTests/Namers/StackTraceParsers/StackTraceParser.cs
@@ -38,7 +38,7 @@ Either:
 
 Solutions:
 a) Add [MethodImpl(MethodImplOptions.NoInlining)]
-b) Set Build->Opitmize Code to False 
+b) Set Build->Optimize Code to False 
    & Build->Advanced->DebugInfo to Full
 
 or


### PR DESCRIPTION
Small spelling mistake I found today while running tests.