### PR TITLE
Speed improvements + fix sporadic infinite loops due to PID re-use in parent-child

### DIFF
--- a/ApprovalTests.MachineSpecific.Tests/ApprovalTests.MachineSpecific.Tests.csproj
+++ b/ApprovalTests.MachineSpecific.Tests/ApprovalTests.MachineSpecific.Tests.csproj
@@ -71,6 +71,7 @@
   <ItemGroup>
     <Compile Include="Namer\ApprovalResultsTest.cs" />
     <Compile Include="Namer\GenericDiffReporterTest.cs" />
+    <Compile Include="Namer\VisualStudioReporterTest.cs" />
     <Compile Include="NHibernate\Company.cs" />
     <Compile Include="NHibernate\Employee.cs" />
     <Compile Include="NHibernate\Event.cs" />

--- a/ApprovalTests.MachineSpecific.Tests/Namer/VisualStudioReporterTest.cs
+++ b/ApprovalTests.MachineSpecific.Tests/Namer/VisualStudioReporterTest.cs
@@ -1,0 +1,16 @@
+﻿using ApprovalTests.Reporters;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ApprovalTests.MachineSpecific.Tests.Namer
+{
+	[TestClass]
+	public class VisualStudioReporterTest
+	{
+		[TestMethod]
+		public void WhenLaunchedFromVisualStudioThenIsWorkingInThisEnvironmentForTextFiles()
+		{
+			var visualStudioReporter = new VisualStudioReporter();
+			Assert.IsTrue(visualStudioReporter.IsWorkingInThisEnvironment("someFile.txt"));
+		}
+	}
+}

--- a/ApprovalTests/Utilities/ParentProcessUtils.cs
+++ b/ApprovalTests/Utilities/ParentProcessUtils.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
+using System.Runtime.InteropServices;
 
 namespace ApprovalTests.Utilities
 {
@@ -10,16 +9,7 @@ namespace ApprovalTests.Utilities
 	{
 		public static Process GetParentProcess(Process currentProcess)
 		{
-			try
-			{
-				var pc = new PerformanceCounter("Process", "Creating Process Id", currentProcess.ProcessName);
-				using (pc)
-					return Process.GetProcessById((int)pc.RawValue);
-			}
-			catch (Exception)
-			{
-				return null;
-			}
+			return currentProcess.ParentProcess();
 		}
 
 		public static IEnumerable<Process> CurrentProcessWithAncestors()
@@ -27,13 +17,100 @@ namespace ApprovalTests.Utilities
 			return GetSelfAndAncestors(Process.GetCurrentProcess());
 		}
 
-		public static IEnumerable<Process> GetSelfAndAncestors(Process process)
+		public static IEnumerable<Process> GetSelfAndAncestors(Process self)
 		{
+			var processIds = new HashSet<int>();
+
+			var process = self;
 			while (process != null)
 			{
 				yield return process;
-				process = GetParentProcess(process);
+
+				if (processIds.Contains(process.Id))
+				{
+					// loop detected (parent id have been re-allocated to a child process!)
+					yield break;
+				}
+				processIds.Add(process.Id);
+
+				process = process.ParentProcess();
 			}
 		}
+
+
+		private static Process ParentProcess(this Process process)
+		{
+			var parentPid = 0;
+			var processPid = process.Id;
+			const uint TH32_CS_SNAPPROCESS = 2;
+			// Take snapshot of processes
+			var hSnapshot = CreateToolhelp32Snapshot(TH32_CS_SNAPPROCESS, 0);
+			if (hSnapshot == IntPtr.Zero)
+			{
+				return null;
+			}
+
+			var procInfo = new PROCESSENTRY32 { dwSize = (uint)Marshal.SizeOf(typeof(PROCESSENTRY32)) };
+
+
+			// Read first
+			if (Process32First(hSnapshot, ref procInfo) == false)
+			{
+				return null;
+			}
+
+			// Loop through the snapshot
+			do
+			{
+				// If it's me, then ask for my parent.
+				if (processPid == procInfo.th32ProcessID)
+				{
+					parentPid = (int)procInfo.th32ParentProcessID;
+				}
+			}
+
+			while (parentPid == 0 && Process32Next(hSnapshot, ref procInfo)); // Read next
+
+			if (parentPid <= 0)
+			{
+				return null;
+			}
+
+			try
+			{
+				return Process.GetProcessById(parentPid);
+			}
+			catch (ArgumentException)
+			{
+				//Process with an Id of X is not running
+				return null;
+			}
+		}
+
+		[DllImport("kernel32.dll", SetLastError = true)]
+		private static extern IntPtr CreateToolhelp32Snapshot(uint dwFlags, uint th32ProcessId);
+
+		[DllImport("kernel32.dll")]
+		private static extern bool Process32First(IntPtr hSnapshot, ref PROCESSENTRY32 lppe);
+
+
+		[DllImport("kernel32.dll")]
+		private static extern bool Process32Next(IntPtr hSnapshot, ref PROCESSENTRY32 lppe);
+
+		[StructLayout(LayoutKind.Sequential)]
+		private struct PROCESSENTRY32
+		{
+			public uint dwSize;
+			public uint cntUsage;
+			public uint th32ProcessID;
+			public IntPtr th32DefaultHeapID;
+			public uint th32ModuleID;
+			public uint cntThreads;
+			public uint th32ParentProcessID;
+			public int pcPriClassBase;
+			public uint dwFlags;
+			[MarshalAs(UnmanagedType.ByValTStr, SizeConst = 260)]
+			public string szExeFile;
+		};
 	}
 }

--- a/ApprovalTests/WindowsRegistry/WindowsRegistryAssert.cs
+++ b/ApprovalTests/WindowsRegistry/WindowsRegistryAssert.cs
@@ -6,24 +6,29 @@ namespace ApprovalTests.WindowsRegistry
 {
 	public static class WindowsRegistryAssert
 	{
-		public static void HasDword(RegistryKey registryKey, string keyName, string valueName, Int32 expectedValue,
-		                            string failureMessage)
+		public static void HasDword(string keyName, string valueName, int expectedValue, string failureMessage)
 		{
-			var key = registryKey.OpenSubKey(keyName);
+			HasDword(Registry.CurrentUser, keyName, valueName, expectedValue, failureMessage);
+		}
 
-			int actualValue = key == null ? 0 : (int) key.GetValue(valueName, 0);
+		private static void HasDword(RegistryKey registryKey, string keyName, string valueName, int expectedValue, string failureMessage)
+		{
+			var actualValue = ReadIntKeyValue(registryKey, keyName, valueName);
 
 			if (actualValue != expectedValue)
 			{
 				string message = "{0}\r\nMust set DWORD {1}\\{2} : {3} = {4}.".FormatWith(failureMessage, registryKey.Name, keyName, valueName,
-				                                                                     expectedValue);
+																																						 expectedValue);
 				throw new Exception(message);
 			}
 		}
 
-		public static void HasDword(string keyName, string valueName, Int32 expectedValue, string failureMessage)
+		private static int ReadIntKeyValue(RegistryKey registryKey, string keyName, string valueName)
 		{
-			HasDword(Registry.CurrentUser, keyName, valueName, expectedValue, failureMessage);
+			using (var key = registryKey.OpenSubKey(keyName))
+			{
+				return key == null ? 0 : (int)key.GetValue(valueName, 0);
+			}
 		}
 	}
 }


### PR DESCRIPTION
- Use faster call with p/invoke (few ms compared to hundreds with performance counters)

- Try to avoid infinite loops because if the root parent process has died, one child could have re-used the root id, thus in the previous implementation leading to an infinite loop.