### PR TITLE
Line ending normalisation reporting fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,7 @@ pip-log.txt
 RealTests.playlist
 ApprovalTests.Tests/UnixLineEndings.txt
 ApprovalTests.Tests/WindowsLineEndings.txt
+.vs/
+_NCrunch_ApprovalTests/
+*.ncrunchproject
+*.ncrunchsolution

--- a/ApprovalTests/ApprovalTests.csproj
+++ b/ApprovalTests/ApprovalTests.csproj
@@ -36,6 +36,8 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <AssemblyOriginatorKeyFile>$(SolutionDir)\ApprovalsKeyPair.snk</AssemblyOriginatorKeyFile>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -293,12 +295,12 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
-  <Import Project="..\packages\Fody.1.24.0\build\Fody.targets" Condition="Exists('..\packages\Fody.1.24.0\build\Fody.targets')" />
+  <Import Project="..\packages\Fody.1.29.3\build\portable-net+sl+win+wpa+wp\Fody.targets" Condition="Exists('..\packages\Fody.1.29.3\build\portable-net+sl+win+wpa+wp\Fody.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Fody.1.24.0\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.1.24.0\build\Fody.targets'))" />
+    <Error Condition="!Exists('..\packages\Fody.1.29.3\build\portable-net+sl+win+wpa+wp\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.1.29.3\build\portable-net+sl+win+wpa+wp\Fody.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/ApprovalTests/Approvers/FileApprover.cs
+++ b/ApprovalTests/Approvers/FileApprover.cs
@@ -52,7 +52,7 @@ namespace ApprovalTests.Approvers
                 var approvedText = File.ReadAllText(approvedPath).Replace("\r\n", "\n");
 
                 return !Compare(receivedText.ToCharArray(), approvedText.ToCharArray()) ?
-                    new ApprovalMismatchException(receivedPath, approvedPath) :
+                    new ApprovalMismatchException(receivedText, approvedText) :
                     null;
             }
 

--- a/ApprovalTests/packages.config
+++ b/ApprovalTests/packages.config
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AspNetMvc" version="3.0.20105.1" targetFramework="net40" developmentDependency="true" />
-  <package id="EntityFramework" version="5.0.0" targetFramework="net40" developmentDependency="true" />
-  <package id="Fody" version="1.24.0" targetFramework="net40" developmentDependency="true" />
-  <package id="Iesi.Collections" version="3.2.0.4000" targetFramework="net40" developmentDependency="true" />
-  <package id="Microsoft.AspNet.Mvc" version="3.0.20105.1" targetFramework="net40" developmentDependency="true" />
-  <package id="Microsoft.AspNet.Razor" version="1.0.20105.408" targetFramework="net40" developmentDependency="true" />
-  <package id="Microsoft.AspNet.WebPages" version="1.0.20105.408" targetFramework="net40" developmentDependency="true" />
-  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net40" developmentDependency="true" />
-  <package id="NHibernate" version="3.3.3.4001" targetFramework="net40" developmentDependency="true" />
-  <package id="StatePrinter" version="1.0.3" targetFramework="net40" developmentDependency="true" />
-  <package id="Virtuosity.Fody" version="1.19.7.0" targetFramework="net40" developmentDependency="true" />
+  <package id="AspNetMvc" version="3.0.20105.1" targetFramework="net4" developmentDependency="true" />
+  <package id="EntityFramework" version="5.0.0" targetFramework="net4" developmentDependency="true" />
+  <package id="Fody" version="1.29.3" targetFramework="net4" developmentDependency="true" />
+  <package id="Iesi.Collections" version="3.2.0.4000" targetFramework="net4" developmentDependency="true" />
+  <package id="Microsoft.AspNet.Mvc" version="3.0.20105.1" targetFramework="net4" developmentDependency="true" />
+  <package id="Microsoft.AspNet.Razor" version="1.0.20105.408" targetFramework="net4" developmentDependency="true" />
+  <package id="Microsoft.AspNet.WebPages" version="1.0.20105.408" targetFramework="net4" developmentDependency="true" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net4" developmentDependency="true" />
+  <package id="NHibernate" version="3.3.3.4001" targetFramework="net4" developmentDependency="true" />
+  <package id="StatePrinter" version="1.0.3" targetFramework="net4" developmentDependency="true" />
+  <package id="Virtuosity.Fody" version="1.19.10.0" targetFramework="net4" developmentDependency="true" />
 </packages>

--- a/ApprovalUtilities/ApprovalUtilities.csproj
+++ b/ApprovalUtilities/ApprovalUtilities.csproj
@@ -15,6 +15,8 @@
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -132,12 +134,12 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
-  <Import Project="..\packages\Fody.1.24.0\build\Fody.targets" Condition="Exists('..\packages\Fody.1.24.0\build\Fody.targets')" />
+  <Import Project="..\packages\Fody.1.29.3\build\portable-net+sl+win+wpa+wp\Fody.targets" Condition="Exists('..\packages\Fody.1.29.3\build\portable-net+sl+win+wpa+wp\Fody.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Fody.1.24.0\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.1.24.0\build\Fody.targets'))" />
+    <Error Condition="!Exists('..\packages\Fody.1.29.3\build\portable-net+sl+win+wpa+wp\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.1.29.3\build\portable-net+sl+win+wpa+wp\Fody.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/ApprovalUtilities/packages.config
+++ b/ApprovalUtilities/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Fody" version="1.24.0" targetFramework="net35" developmentDependency="true" />
+  <package id="Fody" version="1.29.3" targetFramework="net35" developmentDependency="true" />
   <package id="Iesi.Collections" version="3.2.0.4000" targetFramework="net35" developmentDependency="true" />
   <package id="Mvc2" version="2.0.1" targetFramework="net35" developmentDependency="true" />
   <package id="NHibernate" version="3.3.3.4001" targetFramework="net35" developmentDependency="true" />
-  <package id="Virtuosity.Fody" version="1.19.7.0" targetFramework="net35" developmentDependency="true" />
+  <package id="Virtuosity.Fody" version="1.19.10.0" targetFramework="net35" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
I have a test failing on the build server and cannot get failing locally. I am pretty sure the line ending normalisation is working, but the failure is reporting it is line endings.

This change means that the reported text and actual text are the same so it is possible to diagnose errors.