### PR TITLE
Make it easier to provide additional context

### DIFF
--- a/ApprovalTests/Approvals.cs
+++ b/ApprovalTests/Approvals.cs
@@ -99,6 +99,11 @@ namespace ApprovalTests
 			Verify(writer, GetDefaultNamer(), GetReporter());
 		}
 
+		public static void Verify(IApprovalWriter writer, IApprovalNamer namer)
+		{
+			Verify(writer, namer, GetReporter());
+		}
+
 		public static void VerifyFile(string receivedFilePath)
 		{
 			Verify(new ExistingFileWriter(receivedFilePath));

--- a/ApprovalTests/Namers/UnitTestFrameworkNamer.cs
+++ b/ApprovalTests/Namers/UnitTestFrameworkNamer.cs
@@ -6,6 +6,7 @@ namespace ApprovalTests.Namers
 {
     public class UnitTestFrameworkNamer : IApprovalNamer
     {
+        private readonly string additionalContext;
         private readonly StackTraceParser stackTraceParser;
         private string subdirectory;
 
@@ -15,6 +16,15 @@ namespace ApprovalTests.Namers
             stackTraceParser = new StackTraceParser();
             stackTraceParser.Parse(Approvals.CurrentCaller.StackTrace);
             HandleSubdirectory();
+        }
+
+        /// <summary>
+        /// For data driven tests and other scenarios where you want multiple approvals per test
+        /// </summary>
+        /// <param name="additionalContext">Will be added between the test name and the received.ext or approved.ext</param>
+        public UnitTestFrameworkNamer(string additionalContext) : this()
+        {
+            this.additionalContext = additionalContext;
         }
 
         private void HandleSubdirectory()
@@ -28,7 +38,12 @@ namespace ApprovalTests.Namers
 
         public string Name
         {
-            get { return stackTraceParser.ApprovalName; }
+            get
+            {
+                if (!string.IsNullOrEmpty(additionalContext))
+                    return string.Concat(stackTraceParser.ApprovalName, ".", additionalContext);
+                return stackTraceParser.ApprovalName;
+            }
         }
 
         public string SourcePath


### PR DESCRIPTION
This allows data driven tests to have an approved file per run of the data driven test, or other scenarios where you may want multiple approved files per test (end to end tests)

See https://github.com/DbUp/DbUp/pull/109/files#diff-fd8e155b7583c5bd170872f91aa0ceb2R34 for an example of why I want this