### PR TITLE
Fix for issue #140

### DIFF
--- a/ApprovalTests.Tests/ApprovalTests.Tests.csproj
+++ b/ApprovalTests.Tests/ApprovalTests.Tests.csproj
@@ -140,6 +140,7 @@
     <Compile Include="CleanupReporter.cs" />
     <Compile Include="CombinationApprovalsTests.cs" />
     <Compile Include="Core\Exceptions\SerializableExceptionsTest.cs" />
+    <Compile Include="Issues\CustomNamerShouldBeSubstitutableTest.cs" />
     <Compile Include="ExceptionalExceptions\ExceptionExceptionsTest.cs" />
     <Compile Include="Namer\StackTraceParsers\StackTraceParserTests.cs" />
     <Compile Include="Persistence\AsyncSaverTest.cs" />

--- a/ApprovalTests.Tests/Issues/CustomNamerShouldBeSubstitutable.approved.txt
+++ b/ApprovalTests.Tests/Issues/CustomNamerShouldBeSubstitutable.approved.txt
@@ -1,0 +1,1 @@
+﻿CustomNamerShouldBeSubstitutable

--- a/ApprovalTests.Tests/Issues/CustomNamerShouldBeSubstitutableTest.cs
+++ b/ApprovalTests.Tests/Issues/CustomNamerShouldBeSubstitutableTest.cs
@@ -1,0 +1,50 @@
+﻿using ApprovalTests.Core;
+using ApprovalTests.Namers.StackTraceParsers;
+using ApprovalTests.Tests.Reporters;
+using ApprovalTests.Writers;
+using ApprovalUtilities.CallStack;
+using NUnit.Framework;
+
+namespace ApprovalTests.Tests.CustomImplementation
+{
+	[TestFixture]
+	public class CustomNamerShouldBeSubstitutableTest
+	{
+		/// <summary>
+		/// Test for Issue #140
+		/// https://github.com/approvals/ApprovalTests.Net/issues/140
+		/// </summary>
+		[Test]
+		public void CustomNamerShouldNotDependOnSetCallerTest()
+		{
+			var approvaltext = "CustomNamerShouldBeSubstitutable";
+
+			var writer = WriterFactory.CreateTextWriter(approvaltext);
+			var namer = new CustomNamer();
+			var reporter = new MethodLevelReporter();
+
+			Approvals.Verify(writer, namer, reporter);
+		}
+
+		private class CustomNamer : IApprovalNamer
+		{
+			public string Name
+			{
+				get
+				{
+					return "CustomNamerShouldBeSubstitutable";
+				}
+			}
+
+			public string SourcePath
+			{
+				get
+				{
+					var stackTraceParser = new StackTraceParser();
+					stackTraceParser.Parse(new Caller().StackTrace);
+					return stackTraceParser.SourcePath;
+				}
+			}
+		}
+	}
+}

--- a/ApprovalTests/Approvals.cs
+++ b/ApprovalTests/Approvals.cs
@@ -27,7 +27,7 @@ namespace ApprovalTests
         {
             get
             {
-                if (currentCaller == null)
+                if (currentCaller == null || currentCaller.Value==null)
                 {
                     SetCaller();
                 }


### PR DESCRIPTION
https://github.com/approvals/ApprovalTests.Net/issues/140

- Unittest showing issue when not calling Aprovals.SetCaller() with a custom IApprovalNamer.
- Fix in getting CurrentCaller by also garding for null in currentCaller.Value