### PR TITLE
Make ApprovalTests depend on the corresponding ApprovalUtilities

### DIFF
--- a/ApprovalTests/ApprovalTests.nuspec
+++ b/ApprovalTests/ApprovalTests.nuspec
@@ -16,7 +16,7 @@
     <tags>Approvals ApprovalTests ApprovalTest Test Verification Verify Approve Testing</tags>
     <dependencies>
       <group targetFramework=".NETFramework3.5">
-        <dependency id="ApprovalUtilities" />
+        <dependency id="ApprovalUtilities" version="$version$" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
When I add ApprovalTests today, it always grabs an old version of ApprovalUtilities.