### PR TITLE
Make clipboard reporter work from Run

### DIFF
--- a/ApprovalTests/Reporters/QuietReporter.cs
+++ b/ApprovalTests/Reporters/QuietReporter.cs
@@ -22,7 +22,7 @@ namespace ApprovalTests.Reporters
 
 		public static string GetCommandLineForApproval(string approved, string received)
 		{
-			return string.Format("move /Y \"{0}\" \"{1}\"", received, approved);
+			return string.Format("cmd /c move /Y \"{0}\" \"{1}\"", received, approved);
 		}
 
 		public bool IsWorkingInThisEnvironment(string forFile)


### PR DESCRIPTION
- Windows-R opens the Run dialog box. With `cmd /c` the command will work there.

- In PowerShell `move /Y` doesn't work, but with `cmd /c` it will work there, too.