### PR TITLE
Close window after WPF assertion

### DIFF
--- a/ApprovalTests/Wpf/WpfBindingsAssert.cs
+++ b/ApprovalTests/Wpf/WpfBindingsAssert.cs
@@ -20,6 +20,7 @@ namespace ApprovalTests.Wpf
 				Window window = process();
 				window.DataContext = viewModel;
 				window.Show(); // force binding
+				window.Close();
 			}
 		}
 	}


### PR DESCRIPTION
While most test runners close the process when they're done, NCrunch keeps the process open, leaving the window visible on the desktop.