### PR TITLE
Improve support of xunit2

### DIFF
--- a/ApprovalTests.Xunit/ApprovalTests.Xunit.csproj
+++ b/ApprovalTests.Xunit/ApprovalTests.Xunit.csproj
@@ -47,6 +47,7 @@
     <Compile Include="Namer\XunitTheoryStackTraceParserTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Reporters\NonNUnitReporterTest.cs" />
+    <Compile Include="CompatibilityWithXunit2Tests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ApprovalTests\ApprovalTests.csproj">

--- a/ApprovalTests.Xunit/CompatibilityWithXunit2Tests.cs
+++ b/ApprovalTests.Xunit/CompatibilityWithXunit2Tests.cs
@@ -1,0 +1,15 @@
+using ApprovalTests.Reporters;
+using Xunit;
+
+namespace ApprovalTests.Xunit
+{
+    public class CompatibilityWithXunit2Tests
+    {
+        [Fact]
+        [UseReporter(typeof(FrameworkAssertReporter))]
+        public void XunitShouldBeChosenFromFrameworkAssertReporter()
+        {
+            Approvals.Verify("this should work");
+        }
+    }
+}

--- a/ApprovalTests.Xunit2/ApprovalTests.Xunit2.csproj
+++ b/ApprovalTests.Xunit2/ApprovalTests.Xunit2.csproj
@@ -48,6 +48,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CompatibilityWithXunit1Test.cs" />
     <Compile Include="Namer\XunitStackTraceNamerTest.cs" />
     <Compile Include="Namer\XunitTheoryStackTraceParserTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/ApprovalTests.Xunit2/CompatibilityWithXunit1Test.cs
+++ b/ApprovalTests.Xunit2/CompatibilityWithXunit1Test.cs
@@ -1,0 +1,15 @@
+using ApprovalTests.Reporters;
+using Xunit;
+
+namespace ApprovalTests.Xunit2
+{
+    public class CompatibilityWithXunit1Test
+    {
+        [Fact]
+        [UseReporter(typeof(FrameworkAssertReporter))]
+        public void Xunit2ShouldWrokWithFrameworkAssertReporter()
+        {
+            Approvals.Verify("this should work");
+        }
+    }
+}

--- a/ApprovalTests/Reporters/FrameworkAssertReporter.cs
+++ b/ApprovalTests/Reporters/FrameworkAssertReporter.cs
@@ -6,6 +6,7 @@ namespace ApprovalTests.Reporters
 		public FrameworkAssertReporter()
 			: base(MsTestReporter.INSTANCE,
 						 NUnitReporter.INSTANCE,
+						 XUnit2Reporter.INSTANCE,
 						 XUnitReporter.INSTANCE)
 		{
 		}

--- a/ApprovalTests/Reporters/XUnit2Reporter.cs
+++ b/ApprovalTests/Reporters/XUnit2Reporter.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace ApprovalTests.Reporters
 {
     using System.Linq;
@@ -7,10 +9,24 @@ namespace ApprovalTests.Reporters
     public class XUnit2Reporter : AssertReporter
     {
         public readonly static XUnit2Reporter INSTANCE = new XUnit2Reporter();
+        private static readonly Lazy<bool> isXunit2 = new Lazy<bool>(IsXunit2);
+
+        private static bool IsXunit2()
+        {
+            return AppDomain
+                    .CurrentDomain
+                    .GetAssemblies()
+                    .Any(a => a.FullName.Contains("xunit.assert"));
+        }
 
         public XUnit2Reporter()
             : base("Xunit.Assert, xunit.assert", "Equal", XUnitStackTraceParser.Attribute)
         {
+        }
+
+        public override bool IsWorkingInThisEnvironment(string forFile)
+        {
+            return base.IsWorkingInThisEnvironment(forFile) && isXunit2.Value;
         }
 
         protected override void InvokeEqualsMethod(System.Type type, string[] parameters)


### PR DESCRIPTION
Default configuration of `FrameworkAssertApproval` does not consider xunit2 at
all. As a result xunit2 tests are failing on continuous integration servers
because ApprovalTests handles them as xunit ones and tries to invoke missing
assert method. The error is the same as in #159.

Besides of making `FrameworkAssertApproval` aware of xunit2 I've added more
smartess to xunit2 reporter itself. Otherwise it conflicted with xunit.
