### PR TITLE
Add UseFirstWorkingReporterAttribute

### DIFF
--- a/ApprovalTests.Tests/ApprovalTests.Tests.csproj
+++ b/ApprovalTests.Tests/ApprovalTests.Tests.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Persistence\AsyncSaverTest.cs" />
     <Compile Include="Reporters\PowerShellClipboardReporterTest.cs" />
     <Compile Include="Reporters\ReporterTest.cs" />
+    <Compile Include="Reporters\UseFirstWorkingReporterAttributeTest.cs" />
     <Compile Include="RunMaintenance.cs" />
     <Compile Include="Email\EmailTest.cs" />
     <Compile Include="EntityFramework\CompanyList.cs" />

--- a/ApprovalTests.Tests/Reporters/UseFirstWorkingReporterAttributeTest.cs
+++ b/ApprovalTests.Tests/Reporters/UseFirstWorkingReporterAttributeTest.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using ApprovalTests.Core;
+using ApprovalTests.Reporters;
+using NUnit.Framework;
+
+namespace ApprovalTests.Tests.Reporters
+{
+    [TestFixture]
+    public class UseFirstWorkingReporterAttributeTest
+    {
+        [Test]
+        public void UseFirstWorkingReporterAttribute_requires_environment_aware_reporter()
+        {
+            var nonEnviroAware = typeof(NotEnvironmentAwareReporter);
+            var ex = Assert.Throws<InvalidCastException>(() =>
+            {
+                new UseFirstWorkingReporterAttribute(nonEnviroAware);
+            });
+            Assert.That(ex.Message, Is.StringContaining("IEnvironmentAwareReporter"));
+        }
+
+        [Test]
+        public void UseFirstWorkingReporterAttribute_uses_first_working_reporter()
+        {
+            var nonWorking = typeof(NonWorkingReporter);
+            var alwaysSucceeds = typeof(AlwaysSucceedsReporter);
+            var alwaysFails = typeof(AlwaysFailsReporter);
+            var attribute = new UseFirstWorkingReporterAttribute(nonWorking, alwaysSucceeds, alwaysFails);
+            var reporter = attribute.Reporter;
+
+            Assert.That(((FirstWorkingReporter)reporter).IsWorkingInThisEnvironment(""), Is.True);
+            Assert.DoesNotThrow(()=> reporter.Report("", "doesn't match"));
+        }
+
+        [Test]
+        public void UseFirstWorkingReporterAttribute_requires_all_reporters_to_be_environment_aware()
+        {
+            var nonEnviroAware1 = typeof(AppConfigReporter);
+            var nonEnviroAware2 = typeof(NotEnvironmentAwareReporter);
+            var ex = Assert.Throws<InvalidCastException>(()=>
+            {
+                new UseFirstWorkingReporterAttribute(nonEnviroAware1, nonEnviroAware2);
+            });
+            Assert.That(ex.Message, Is.StringContaining("IEnvironmentAwareReporter"));
+        }
+    }
+
+    class AlwaysSucceedsReporter : IEnvironmentAwareReporter
+    {
+        public void Report(string approved, string received)
+        {
+        }
+
+        public bool IsWorkingInThisEnvironment(string forFile)
+        {
+            return true;
+        }
+    }
+    class AlwaysFailsReporter : IEnvironmentAwareReporter
+    {
+        public void Report(string approved, string received)
+        {
+            throw new Exception("this reporter always fails");
+        }
+
+        public bool IsWorkingInThisEnvironment(string forFile)
+        {
+            return true;
+        }
+    }
+    class NonWorkingReporter : IEnvironmentAwareReporter
+    {
+        public void Report(string approved, string received)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsWorkingInThisEnvironment(string forFile)
+        {
+            return false;
+        }
+    }
+    class NotEnvironmentAwareReporter : IApprovalFailureReporter
+    {
+        public void Report(string approved, string received)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}
+

--- a/ApprovalTests/ApprovalTests.csproj
+++ b/ApprovalTests/ApprovalTests.csproj
@@ -148,6 +148,7 @@
     <Compile Include="Reporters\ReportWithoutFrontLoading.cs" />
     <Compile Include="Reporters\TfsVnextReporter.cs" />
     <Compile Include="Reporters\QueryResult.cs" />
+    <Compile Include="Reporters\UseFirstWorkingReporterAttribute.cs" />
     <Compile Include="Reporters\WindowsDiffReporter.cs" />
     <Compile Include="Reporters\XUnit2Reporter.cs" />
     <Compile Include="Scrubber\HtmlScrubbers.cs" />

--- a/ApprovalTests/Reporters/IntroductionReporter.cs
+++ b/ApprovalTests/Reporters/IntroductionReporter.cs
@@ -23,12 +23,13 @@ namespace ApprovalTests.Reporters
                 @"Welcome to ApprovalTests.
 
 Please add:
-
 [UseReporter(typeof(DiffReporter))]
+or
+[UseFirstWorkingReporter(typeof(DiffReporter), typeof(QuietReporter)]
 to your Class, Method or assembly.
 
 Why:
-ApprovalTests uses the [UseReporter] attribute from your test class, method or assembly.
+ApprovalTests uses the [UseReporter] or [UseFirstWorkingReporter] attribute from your test class, method or assembly.
 When you do this ApprovalTest will launch the result using that reporter (for example in your diff tool).
 You can find several reporters in ApprovalTests.Reporters namespace, or create your own by extending {0}) interface.
 Find more at: http://blog.approvaltests.com/2011/12/using-reporters-in-approval-tests.html

--- a/ApprovalTests/Reporters/UseFirstWorkingReporterAttribute.cs
+++ b/ApprovalTests/Reporters/UseFirstWorkingReporterAttribute.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using ApprovalTests.Core;
+
+namespace ApprovalTests.Reporters
+{
+    [AttributeUsage(AttributeTargets.All)]
+    [Description("Use the first reporter that works in the current environment")]
+    public class UseFirstWorkingReporterAttribute : UseReporterAttribute
+    {
+        public UseFirstWorkingReporterAttribute(Type reporterType)
+        {
+            var reporter = (IEnvironmentAwareReporter) Activator.CreateInstance(reporterType);
+            SetReporter(reporter);
+        }
+
+        //This constructor keeps the Attribute CLS-compliant for two parameters.
+        //Using more than two constructor parameters will use the params constructor which is not CLS-compliant
+        public UseFirstWorkingReporterAttribute(Type reporterType, Type reporterType2)
+        {
+            var reporter = (IEnvironmentAwareReporter) Activator.CreateInstance(reporterType);
+            var reporter2 = (IEnvironmentAwareReporter)Activator.CreateInstance(reporterType2);
+            SetReporter(reporter, reporter2);
+        }
+
+        public UseFirstWorkingReporterAttribute(params Type[] reporterTypes)
+        {
+            var reporters = reporterTypes
+                .Select(reporterType => (IEnvironmentAwareReporter) Activator.CreateInstance(reporterType) )
+                .ToArray();
+            SetReporter(reporters);
+        }
+
+        private void SetReporter(params IEnvironmentAwareReporter[] reporters)
+        {
+            Reporter = new FirstWorkingReporter(reporters);
+        }
+    }
+}


### PR DESCRIPTION
When using ApprovalTests, this new attribute lets me just set up the code and use it without managing configuration files or changing code for different test environments.

I usually set it this way for my workflow:
[UseFirstWorkingReporter(typeof(NCrunchReporter), typeof(DiffReporter), typeof(TeamCityReporter))]

That lets it run silently when I have NCrunch turned on, get a merge tool when I run tests manually, and when I push, they run on TeamCity.
