### PR TITLE
Add parent class names to files written for nested classes

### DIFF
--- a/ApprovalTests.Tests/Namer/ApprovalResultsTest.cs
+++ b/ApprovalTests.Tests/Namer/ApprovalResultsTest.cs
@@ -77,5 +77,16 @@ namespace ApprovalTests.Tests.Namer
                 }
             }
         }
+
+        [TestFixture]
+        public class NestedClassTests
+        {
+            [Test]
+            public void WithNestedClass()
+            {
+                var name = Approvals.GetDefaultNamer().Name;
+                Assert.AreEqual("AdditionalInformationTests.NestedClassTests.WithNestedClass", name);
+            }
+        }
     }
 }

--- a/ApprovalTests/Namers/StackTraceParsers/AttributeStackTraceParser.cs
+++ b/ApprovalTests/Namers/StackTraceParsers/AttributeStackTraceParser.cs
@@ -15,7 +15,7 @@ namespace ApprovalTests.Namers.StackTraceParsers
 
 		public string TypeName
 		{
-			get { return approvalFrame.Method.DeclaringType.Name; }
+		    get { return GetRecursiveTypeName(this.approvalFrame.Method.DeclaringType); }
 		}
 
 		public string AdditionalInfo
@@ -84,5 +84,12 @@ namespace ApprovalTests.Namers.StackTraceParsers
 		}
 
 		protected abstract string GetAttributeType();
+
+	    private static string GetRecursiveTypeName(Type type)
+	    {
+	        return type.DeclaringType != null 
+                ? $"{GetRecursiveTypeName(type.DeclaringType)}.{type.Name}" 
+                : type.Name;
+	    }
 	}
 }


### PR DESCRIPTION
Given a nested test class structure:
```csharp
[TestFixture]
public class Parent
{
    [TestFixture]
    public class Nested
    {
        [Test]
        public void TestMethod()
        {
        }
    }
}
```

The files would be named `Nested.TestMethod.*.*`
However if you have the same structure in a different class with the same nested class & test method naming, these file names would conflict.

So this will instead make the filename be `Parent.Nested.TestMethod.*.*`