### PR TITLE
Add set approvals

### DIFF
--- a/ApprovalTests.Tests/ApprovalTests.Tests.csproj
+++ b/ApprovalTests.Tests/ApprovalTests.Tests.csproj
@@ -127,6 +127,7 @@
     <Compile Include="Namer\ApprovalResultsTest.cs" />
     <Compile Include="Namer\SubdirectoryNamerTests.cs" />
     <Compile Include="Pdf\PdfTest.cs" />
+    <Compile Include="Set\SetTests.cs" />
     <Compile Include="StackTraceScrubberTest.cs" />
     <Compile Include="StatePrinter\StatePrinterTests.cs" />
     <Compile Include="StringEncodingTest.cs" />

--- a/ApprovalTests.Tests/Set/SetTests.TestFile.approved.txt
+++ b/ApprovalTests.Tests/Set/SetTests.TestFile.approved.txt
@@ -1,0 +1,3 @@
+﻿2017-01-13 20:30:02.5369|INFO|Approvals.Class1|Test message
+2017-01-13 20:30:02.5599|INFO|Approvals.Class1|A third line
+2017-01-13 20:30:02.5599|INFO|Approvals.Class1|Another line

--- a/ApprovalTests.Tests/Set/SetTests.TestFileWithScrubber.approved.txt
+++ b/ApprovalTests.Tests/Set/SetTests.TestFileWithScrubber.approved.txt
@@ -1,0 +1,3 @@
+﻿|INFO|Approvals.Class1|A third line
+|INFO|Approvals.Class1|Another line
+|INFO|Approvals.Class1|Test message

--- a/ApprovalTests.Tests/Set/SetTests.TestListObject.approved.txt
+++ b/ApprovalTests.Tests/Set/SetTests.TestListObject.approved.txt
@@ -1,0 +1,3 @@
+﻿[0] = apple
+[1] = banana
+[2] = carrot

--- a/ApprovalTests.Tests/Set/SetTests.TestListString.approved.txt
+++ b/ApprovalTests.Tests/Set/SetTests.TestListString.approved.txt
@@ -1,0 +1,3 @@
+﻿[0] = apple
+[1] = banana
+[2] = carrot

--- a/ApprovalTests.Tests/Set/SetTests.cs
+++ b/ApprovalTests.Tests/Set/SetTests.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using ApprovalTests.Set;
+using ApprovalTests.Reporters;
+using ApprovalUtilities.Utilities;
+using System.Text.RegularExpressions;
+
+namespace ApprovalTests.Tests.Set
+{
+    [TestFixture]
+    public class SetTests
+    {
+        [Test]
+        public void TestListString()
+        {
+            // Approved file has order apple, banana, carrot
+            var list = new List<string>() { "carrot", "apple", "banana" };
+            SetApprovals.VerifySet(list, String.Empty);
+        }
+
+        public class Foo: IComparable<Foo>
+        {
+            public string Bar { get; set; }
+
+            public int CompareTo(Foo other)
+            {
+                return this.Bar.CompareTo(other.Bar);
+            }
+        }
+
+        [Test]
+        public void TestListObject()
+        {
+            var list = new List<Foo>()
+            {
+                new Foo() { Bar = "carrot" },
+                new Foo() { Bar = "apple" },
+                new Foo() { Bar = "banana" },
+            };
+            SetApprovals.VerifySet(list, String.Empty, f => f.Bar);
+        }
+
+        [Test]
+        public void TestFile()
+        {
+            var path = PathUtilities.GetDirectoryForCaller();
+            var file = path + "a.txt";
+            SetApprovals.VerifyFileAsSet(file);
+        }
+
+        [Test]
+        public void TestFileWithScrubber()
+        {
+            var path = PathUtilities.GetDirectoryForCaller();
+            var file = path + "a.txt";
+            Func<string, string> scrubber =  s => Regex.Replace(s, @"^[^\|]*", "");
+            SetApprovals.VerifyFileAsSet(file, scrubber);
+        }
+    }
+}

--- a/ApprovalTests.Tests/Set/a.txt
+++ b/ApprovalTests.Tests/Set/a.txt
@@ -1,0 +1,3 @@
+2017-01-13 20:30:02.5369|INFO|Approvals.Class1|Test message
+2017-01-13 20:30:02.5599|INFO|Approvals.Class1|Another line
+2017-01-13 20:30:02.5599|INFO|Approvals.Class1|A third line

--- a/ApprovalTests/ApprovalTests.csproj
+++ b/ApprovalTests/ApprovalTests.csproj
@@ -209,6 +209,7 @@
     <Compile Include="Namers\UnitTestFrameworks\MbUnitStackTraceParser.cs" />
     <Compile Include="Namers\UnitTestFrameworks\VSStackTraceParser.cs" />
     <Compile Include="Reporters\UseReporterAttribute.cs" />
+    <Compile Include="Set\SetApprovals.cs" />
     <Compile Include="TheoryTests\ThreadSafteyTheory.cs" />
     <Compile Include="Utilities\OSUtils.cs" />
     <Compile Include="Utilities\ParentProcessUtils.cs" />

--- a/ApprovalTests/Set/SetApprovals.cs
+++ b/ApprovalTests/Set/SetApprovals.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace ApprovalTests.Set
+{
+    public static class SetApprovals
+    {
+        private static IEnumerable<T> GetSorted<T>(IEnumerable<T> enumerable) where T:IComparable<T>
+        {
+            return enumerable.OrderBy(e => e);
+        }
+
+        public static void VerifySet<T>(IEnumerable<T> enumerable, Func<T, string> formatter) where T : IComparable<T>
+        {
+            Approvals.VerifyAll(GetSorted(enumerable), formatter);
+        }
+
+        public static void VerifySet<T>(IEnumerable<T> enumerable, string label) where T : IComparable<T>
+        {
+            Approvals.VerifyAll(GetSorted(enumerable), label);
+        }
+
+        public static void VerifySet<T>(IEnumerable<T> enumerable, string label, Func<T, string> formatter) where T : IComparable<T>
+        {
+            Approvals.VerifyAll(GetSorted(enumerable), label, formatter);
+        }
+
+        public static void VerifySet<T>(string header, IEnumerable<T> enumerable, string label) where T : IComparable<T>
+        {
+            Approvals.VerifyAll(header, GetSorted(enumerable), label);
+        }
+
+        public static void VerifySet<T>(string header, IEnumerable<T> enumerable, Func<T, string> formatter) where T : IComparable<T>
+        {
+            Approvals.VerifyAll(header, GetSorted(enumerable), formatter);
+        }
+
+        public static void VerifyFileAsSet(string filename, Func<string, string> scrubber)
+        {
+            var lines = File.ReadAllLines(filename);
+            var scrubbed = lines.Select(l => scrubber(l));
+            VerifySet(scrubbed, s => s);  
+        }
+
+        public static void VerifyFileAsSet(string filename)
+        {
+            VerifyFileAsSet(filename, ApprovalTests.Scrubber.ScrubberUtils.NO_SCRUBBER);
+        }
+    }
+}


### PR DESCRIPTION
I had a need to be able to run `VerifyFile()` on a log file in which the timestamps would be different each time and I couldn't guarantee the order of the log lines. So I wanted to be able to run a scrubber over each line to remove the timestamp and then to compare the lines regardless of order.

Where this led me was adding `VerifySet()` methods that correspond to `VerifyAll()`, the difference being that `VerifySet()` first sorts the incoming `IEnumerable`. The effect is that the order of the elements is normalized each time so that received can be compared to approved as a set, rather than as an ordered list.

Then I added versions of `VerifyFileAsSet()`, both with and without a scrubber, that treat a text file as `IEnumerable<string>` and call `VerifySet()`.

These are very useful to me in the work I'm currently doing; not sure if you're interested in incorporating them into the library.