### PR TITLE
Fix typo

### DIFF
--- a/ApprovalTests.Tests/ApprovalTests.Tests.csproj
+++ b/ApprovalTests.Tests/ApprovalTests.Tests.csproj
@@ -127,6 +127,7 @@
     <Compile Include="Namer\ApprovalResultsTest.cs" />
     <Compile Include="Namer\SubdirectoryNamerTests.cs" />
     <Compile Include="Pdf\PdfTest.cs" />
+    <Compile Include="Set\SetTests.cs" />
     <Compile Include="StackTraceScrubberTest.cs" />
     <Compile Include="StatePrinter\StatePrinterTests.cs" />
     <Compile Include="StringEncodingTest.cs" />

--- a/ApprovalTests.Tests/Set/SetTests.TestFile.approved.txt
+++ b/ApprovalTests.Tests/Set/SetTests.TestFile.approved.txt
@@ -1,0 +1,3 @@
+﻿2017-01-13 20:30:02.5369|INFO|Approvals.Class1|Test message
+2017-01-13 20:30:02.5599|INFO|Approvals.Class1|A third line
+2017-01-13 20:30:02.5599|INFO|Approvals.Class1|Another line

--- a/ApprovalTests.Tests/Set/SetTests.TestFileWithScrubber.approved.txt
+++ b/ApprovalTests.Tests/Set/SetTests.TestFileWithScrubber.approved.txt
@@ -1,0 +1,3 @@
+﻿|INFO|Approvals.Class1|A third line
+|INFO|Approvals.Class1|Another line
+|INFO|Approvals.Class1|Test message

--- a/ApprovalTests.Tests/Set/SetTests.TestListObject.approved.txt
+++ b/ApprovalTests.Tests/Set/SetTests.TestListObject.approved.txt
@@ -1,0 +1,3 @@
+﻿[0] = apple
+[1] = banana
+[2] = carrot

--- a/ApprovalTests.Tests/Set/SetTests.TestListString.approved.txt
+++ b/ApprovalTests.Tests/Set/SetTests.TestListString.approved.txt
@@ -1,0 +1,3 @@
+﻿[0] = apple
+[1] = banana
+[2] = carrot

--- a/ApprovalTests.Tests/Set/SetTests.cs
+++ b/ApprovalTests.Tests/Set/SetTests.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using ApprovalTests.Set;
+using ApprovalTests.Reporters;
+using ApprovalUtilities.Utilities;
+using System.Text.RegularExpressions;
+
+namespace ApprovalTests.Tests.Set
+{
+    [TestFixture]
+    public class SetTests
+    {
+        [Test]
+        public void TestListString()
+        {
+            // Approved file has order apple, banana, carrot
+            var list = new List<string>() { "carrot", "apple", "banana" };
+            SetApprovals.VerifySet(list, String.Empty);
+        }
+
+        public class Foo: IComparable<Foo>
+        {
+            public string Bar { get; set; }
+
+            public int CompareTo(Foo other)
+            {
+                return this.Bar.CompareTo(other.Bar);
+            }
+        }
+
+        [Test]
+        public void TestListObject()
+        {
+            var list = new List<Foo>()
+            {
+                new Foo() { Bar = "carrot" },
+                new Foo() { Bar = "apple" },
+                new Foo() { Bar = "banana" },
+            };
+            SetApprovals.VerifySet(list, String.Empty, f => f.Bar);
+        }
+
+        [Test]
+        public void TestFile()
+        {
+            var path = PathUtilities.GetDirectoryForCaller();
+            var file = path + "a.txt";
+            SetApprovals.VerifyFileAsSet(file);
+        }
+
+        [Test]
+        public void TestFileWithScrubber()
+        {
+            var path = PathUtilities.GetDirectoryForCaller();
+            var file = path + "a.txt";
+            Func<string, string> scrubber =  s => Regex.Replace(s, @"^[^\|]*", "");
+            SetApprovals.VerifyFileAsSet(file, scrubber);
+        }
+    }
+}

--- a/ApprovalTests.Tests/Set/a.txt
+++ b/ApprovalTests.Tests/Set/a.txt
@@ -1,0 +1,3 @@
+2017-01-13 20:30:02.5369|INFO|Approvals.Class1|Test message
+2017-01-13 20:30:02.5599|INFO|Approvals.Class1|Another line
+2017-01-13 20:30:02.5599|INFO|Approvals.Class1|A third line

--- a/ApprovalTests/ApprovalTests.csproj
+++ b/ApprovalTests/ApprovalTests.csproj
@@ -209,6 +209,7 @@
     <Compile Include="Namers\UnitTestFrameworks\MbUnitStackTraceParser.cs" />
     <Compile Include="Namers\UnitTestFrameworks\VSStackTraceParser.cs" />
     <Compile Include="Reporters\UseReporterAttribute.cs" />
+    <Compile Include="Set\SetApprovals.cs" />
     <Compile Include="TheoryTests\ThreadSafteyTheory.cs" />
     <Compile Include="Utilities\OSUtils.cs" />
     <Compile Include="Utilities\ParentProcessUtils.cs" />

--- a/ApprovalTests/Reporters/GenericDiffReporter.cs
+++ b/ApprovalTests/Reporters/GenericDiffReporter.cs
@@ -120,7 +120,7 @@ Recieved {0} ({1}, {2}, {3})"
                 return fullPath;
             }
             var toFind = Path.GetFileName(fullPath);
-            var output = PathUtilities.LocateFileFromEnviormentPath(toFind).FirstOrDefault();
+            var output = PathUtilities.LocateFileFromEnvironmentPath(toFind).FirstOrDefault();
             return String.IsNullOrEmpty(output) ? fullPath : output;
         }
 

--- a/ApprovalTests/Set/SetApprovals.cs
+++ b/ApprovalTests/Set/SetApprovals.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace ApprovalTests.Set
+{
+    public static class SetApprovals
+    {
+        private static IEnumerable<T> GetSorted<T>(IEnumerable<T> enumerable) where T:IComparable<T>
+        {
+            return enumerable.OrderBy(e => e);
+        }
+
+        public static void VerifySet<T>(IEnumerable<T> enumerable, Func<T, string> formatter) where T : IComparable<T>
+        {
+            Approvals.VerifyAll(GetSorted(enumerable), formatter);
+        }
+
+        public static void VerifySet<T>(IEnumerable<T> enumerable, string label) where T : IComparable<T>
+        {
+            Approvals.VerifyAll(GetSorted(enumerable), label);
+        }
+
+        public static void VerifySet<T>(IEnumerable<T> enumerable, string label, Func<T, string> formatter) where T : IComparable<T>
+        {
+            Approvals.VerifyAll(GetSorted(enumerable), label, formatter);
+        }
+
+        public static void VerifySet<T>(string header, IEnumerable<T> enumerable, string label) where T : IComparable<T>
+        {
+            Approvals.VerifyAll(header, GetSorted(enumerable), label);
+        }
+
+        public static void VerifySet<T>(string header, IEnumerable<T> enumerable, Func<T, string> formatter) where T : IComparable<T>
+        {
+            Approvals.VerifyAll(header, GetSorted(enumerable), formatter);
+        }
+
+        public static void VerifyFileAsSet(string filename, Func<string, string> scrubber)
+        {
+            var lines = File.ReadAllLines(filename);
+            var scrubbed = lines.Select(l => scrubber(l));
+            VerifySet(scrubbed, s => s);  
+        }
+
+        public static void VerifyFileAsSet(string filename)
+        {
+            VerifyFileAsSet(filename, ApprovalTests.Scrubber.ScrubberUtils.NO_SCRUBBER);
+        }
+    }
+}

--- a/ApprovalTests/Utilities/TestCounter.cs
+++ b/ApprovalTests/Utilities/TestCounter.cs
@@ -48,7 +48,7 @@ namespace ApprovalTests.Utilities
 
         public static void ResetAndLaunch(string counterDisplayJar)
         {
-            var javaPath = PathUtilities.LocateFileFromEnviormentPath("javaw.exe").FirstOrDefault();
+            var javaPath = PathUtilities.LocateFileFromEnvironmentPath("javaw.exe").FirstOrDefault();
             ResetAndLaunch(javaPath, counterDisplayJar);
         }
 

--- a/ApprovalUtilities.Tests/Utilities/PathUtilitiesTest.cs
+++ b/ApprovalUtilities.Tests/Utilities/PathUtilitiesTest.cs
@@ -19,7 +19,7 @@ namespace ApprovalUtilities.Tests.Utilities
 		[TestMethod]
 		public void TestFindsFile()
 		{
-			var found = PathUtilities.LocateFileFromEnviormentPath(@"ipconfig.exe").FirstOrDefault();
+			var found = PathUtilities.LocateFileFromEnvironmentPath(@"ipconfig.exe").FirstOrDefault();
 			AssertEqualIgnoreCase(@"C:\Windows\System32\ipconfig.exe", found);
 		}
 
@@ -31,14 +31,14 @@ namespace ApprovalUtilities.Tests.Utilities
 		[TestMethod]
 		public void TestFindsMultipleFiles()
 		{
-			Approvals.VerifyAll(PathUtilities.LocateFileFromEnviormentPath(@"notepad.exe").Select(f=>f.ToLowerInvariant()), "Found");
+			Approvals.VerifyAll(PathUtilities.LocateFileFromEnvironmentPath(@"notepad.exe").Select(f=>f.ToLowerInvariant()), "Found");
 		}
 
 		[TestMethod]
 		public void TestDoesNotFindFile()
 		{
 			string noneExistingFile = @"ThisFileShouldNotExist.exe";
-			var results = PathUtilities.LocateFileFromEnviormentPath(noneExistingFile);
+			var results = PathUtilities.LocateFileFromEnvironmentPath(noneExistingFile);
 			Assert.AreEqual(0,results.Count());
 		}
 	}

--- a/ApprovalUtilities/Utilities/PathUtilities.cs
+++ b/ApprovalUtilities/Utilities/PathUtilities.cs
@@ -35,7 +35,7 @@ namespace ApprovalUtilities.Utilities
             return GetDirectoryForCaller(1) + relativePath;
         }
 
-        public static IEnumerable<string> LocateFileFromEnviormentPath(string toFind)
+        public static IEnumerable<string> LocateFileFromEnvironmentPath(string toFind)
         {
             var results = new List<string>();
             if (File.Exists(toFind))
@@ -53,6 +53,12 @@ namespace ApprovalUtilities.Utilities
 
             results.AddRange(FindProgramOnPath(toFind));
             return results.ToArray();
+        }
+
+        [Obsolete("Use LocateFileFromEnvironmentPath().")]
+        public static IEnumerable<string> LocateFileFromEnviormentPath(string toFind)
+        {
+            return LocateFileFromEnvironmentPath(toFind);
         }
 
         private static IList<string> EnvironmentPaths;


### PR DESCRIPTION
I happened to notice a misspelled method name; I marked it with `Obsolete` and added the correct spelling.