### PR TITLE
Fix misspelled method name

### DIFF
--- a/ApprovalTests/Reporters/GenericDiffReporter.cs
+++ b/ApprovalTests/Reporters/GenericDiffReporter.cs
@@ -120,7 +120,7 @@ Recieved {0} ({1}, {2}, {3})"
                 return fullPath;
             }
             var toFind = Path.GetFileName(fullPath);
-            var output = PathUtilities.LocateFileFromEnviormentPath(toFind).FirstOrDefault();
+            var output = PathUtilities.LocateFileFromEnvironmentPath(toFind).FirstOrDefault();
             return String.IsNullOrEmpty(output) ? fullPath : output;
         }
 

--- a/ApprovalTests/Utilities/TestCounter.cs
+++ b/ApprovalTests/Utilities/TestCounter.cs
@@ -48,7 +48,7 @@ namespace ApprovalTests.Utilities
 
         public static void ResetAndLaunch(string counterDisplayJar)
         {
-            var javaPath = PathUtilities.LocateFileFromEnviormentPath("javaw.exe").FirstOrDefault();
+            var javaPath = PathUtilities.LocateFileFromEnvironmentPath("javaw.exe").FirstOrDefault();
             ResetAndLaunch(javaPath, counterDisplayJar);
         }
 

--- a/ApprovalUtilities.Tests/Utilities/PathUtilitiesTest.cs
+++ b/ApprovalUtilities.Tests/Utilities/PathUtilitiesTest.cs
@@ -19,7 +19,7 @@ namespace ApprovalUtilities.Tests.Utilities
 		[TestMethod]
 		public void TestFindsFile()
 		{
-			var found = PathUtilities.LocateFileFromEnviormentPath(@"ipconfig.exe").FirstOrDefault();
+			var found = PathUtilities.LocateFileFromEnvironmentPath(@"ipconfig.exe").FirstOrDefault();
 			AssertEqualIgnoreCase(@"C:\Windows\System32\ipconfig.exe", found);
 		}
 
@@ -31,14 +31,14 @@ namespace ApprovalUtilities.Tests.Utilities
 		[TestMethod]
 		public void TestFindsMultipleFiles()
 		{
-			Approvals.VerifyAll(PathUtilities.LocateFileFromEnviormentPath(@"notepad.exe").Select(f=>f.ToLowerInvariant()), "Found");
+			Approvals.VerifyAll(PathUtilities.LocateFileFromEnvironmentPath(@"notepad.exe").Select(f=>f.ToLowerInvariant()), "Found");
 		}
 
 		[TestMethod]
 		public void TestDoesNotFindFile()
 		{
 			string noneExistingFile = @"ThisFileShouldNotExist.exe";
-			var results = PathUtilities.LocateFileFromEnviormentPath(noneExistingFile);
+			var results = PathUtilities.LocateFileFromEnvironmentPath(noneExistingFile);
 			Assert.AreEqual(0,results.Count());
 		}
 	}

--- a/ApprovalUtilities/Utilities/PathUtilities.cs
+++ b/ApprovalUtilities/Utilities/PathUtilities.cs
@@ -35,7 +35,7 @@ namespace ApprovalUtilities.Utilities
             return GetDirectoryForCaller(1) + relativePath;
         }
 
-        public static IEnumerable<string> LocateFileFromEnviormentPath(string toFind)
+        public static IEnumerable<string> LocateFileFromEnvironmentPath(string toFind)
         {
             var results = new List<string>();
             if (File.Exists(toFind))
@@ -53,6 +53,12 @@ namespace ApprovalUtilities.Utilities
 
             results.AddRange(FindProgramOnPath(toFind));
             return results.ToArray();
+        }
+
+        [Obsolete("Use LocateFileFromEnvironmentPath().")]
+        public static IEnumerable<string> LocateFileFromEnviormentPath(string toFind)
+        {
+            return LocateFileFromEnvironmentPath(toFind);
         }
 
         private static IList<string> EnvironmentPaths;


### PR DESCRIPTION
I happened to notice a misspelled method name; I marked it with Obsolete and added the correct spelling.