### PR TITLE
Use StatePrinter v3

### DIFF
--- a/ApprovalTests/ApprovalTests.csproj
+++ b/ApprovalTests/ApprovalTests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="EntityFramework" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Iesi.Collections" Version="4.0.2" PrivateAssets="All" />
     <PackageReference Include="NHibernate" Version="4.1.1.4000" PrivateAssets="All" />
-    <PackageReference Include="StatePrinter" Version="1.0.3" PrivateAssets="All" />
+    <PackageReference Include="StatePrinter" Version="3.0.0" PrivateAssets="All" />
     <PackageReference Include="Fody" Version="2.4.2" PrivateAssests="All" ExcludeAssets="All" />
     <PackageReference Include="Microsoft.AspNet.Mvc" Version="3.0.20105.1" ExcludeAssets="All" />
     <PackageReference Include="Microsoft.AspNet.Razor" Version="1.0.20105.408" ExcludeAssets="All" />

--- a/ApprovalTests/StatePrinter/StatePrinterApprovals.cs
+++ b/ApprovalTests/StatePrinter/StatePrinterApprovals.cs
@@ -1,34 +1,32 @@
 ﻿using System;
-using StatePrinter.Configurations;
+using StatePrinting.Configurations;
 
 namespace ApprovalTests.StatePrinter
 {
-	public static class StatePrinterApprovals
-	{
-		private static Func<Configuration> defaultConfiguration = ConfigurationHelper.GetStandardConfiguration;
+    public static class StatePrinterApprovals
+    {
+        private static Func<Configuration> defaultConfiguration = () => ConfigurationHelper.GetStandardConfiguration(null);
 
-		public static void Verify(object source, string rootName = "Root")
-		{
-			Verify(source, GetDefaultConfiguration(), rootName);
-		}
+        public static void Verify(object source, string rootName = "Root")
+        {
+            Verify(source, GetDefaultConfiguration(), rootName);
+        }
 
+        public static void Verify(object source, Configuration configuration, string rootName = "Root")
+        {
+            var printer = new StatePrinting.Stateprinter(configuration);
+            string printedResult = printer.PrintObject(source, rootName);
+            Approvals.Verify(printedResult);
+        }
 
-		public static void Verify(object source, Configuration configuration, string rootName = "Root")
-		{
-			var printer = new global::StatePrinter.StatePrinter(configuration);
-			string printedResult = printer.PrintObject(source, rootName);
-			Approvals.Verify(printedResult);
-		}
+        public static Configuration GetDefaultConfiguration()
+        {
+            return defaultConfiguration();
+        }
 
-		public static Configuration GetDefaultConfiguration()
-		{
-			return defaultConfiguration();
-		}
-
-		public static void RegisterDefaultConfiguration(Func<Configuration> configurationProducer)
-		{
-			defaultConfiguration = configurationProducer;
-		}
-
-	}
+        public static void RegisterDefaultConfiguration(Func<Configuration> configurationProducer)
+        {
+            defaultConfiguration = configurationProducer;
+        }
+    }
 }


### PR DESCRIPTION
#174 

I believe nuspec should define StatePrinter v3.0.0 as minimum (there is already a v3.0.1). Which would make StatePrinter a hard dependecy.

Or nothing at all, like the way it is now, but then you get runtime errors depending on the version of stateprinter you have installed. In which case this PR resolves the runtime error for people who want to use that latest StatePrinter package.
