### PR TITLE
Add new namer that looks for approval files in same folder as assembly

### DIFF
--- a/ApprovalTests/Namers/AssemblyLocationNamer.cs
+++ b/ApprovalTests/Namers/AssemblyLocationNamer.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+
+namespace ApprovalTests.Namers
+{
+    public class AssemblyLocationNamer : UnitTestFrameworkNamer
+    {
+        private string AssemblyDirectory
+        {
+            get
+            {
+                // CodeBase is used because the NUnit test runner is otherwise quirky
+                var codeBase = Assembly.GetExecutingAssembly().CodeBase;
+                var uri = new UriBuilder(codeBase);
+                var path = Uri.UnescapeDataString(uri.Path);
+                return Path.GetDirectoryName(path);
+            }
+        }
+
+        public override string SourcePath => AssemblyDirectory + GetSubdirectory();
+    }
+}

--- a/ApprovalTests/Namers/UnitTestFrameworkNamer.cs
+++ b/ApprovalTests/Namers/UnitTestFrameworkNamer.cs
@@ -28,7 +28,7 @@ namespace ApprovalTests.Namers
 
         public string Name => stackTraceParser.ApprovalName;
 
-        public string SourcePath => stackTraceParser.SourcePath + GetSubdirectory();
+        public virtual string SourcePath => stackTraceParser.SourcePath + GetSubdirectory();
 
         public string GetSubdirectory()
         {


### PR DESCRIPTION
I had same problems as in #66, used just the namer from PR #71.

To use just call this in your test:
`Approvals.RegisterDefaultNamerCreation(() => new UnitTestFrameworkNamerAssemblyLocation());`

One limitation is that if your test is in a sub-folder you need a post-build copy to destination folder for example:
`copy /y $(ProjectDir)**subfolder**\*.approved.txt $(TargetDir)`