### PR TITLE
XUnit2 Reporter not being chosen from FrameworkAssertReporter #246

### DIFF
--- a/ApprovalTests/Reporters/XUnit2Reporter.cs
+++ b/ApprovalTests/Reporters/XUnit2Reporter.cs
@@ -13,6 +13,31 @@ namespace ApprovalTests.Reporters
 
         private static bool IsXunit2()
         {
+            var firstCheck = AppDomain
+                    .CurrentDomain
+                    .GetAssemblies()
+                    .Any(a => a.FullName.Contains("xunit.assert"));
+
+            if (!firstCheck)
+            {
+                var secondCheck = AppDomain
+                    .CurrentDomain
+                    .GetAssemblies()
+                    .Any(a => a.FullName.Contains("xunit.core"));
+
+                if (secondCheck)
+                {
+                    try
+                    {
+                        var entry = AppDomain.CurrentDomain.Load("xunit.assert");
+                    }
+                    catch (Exception)
+                    {
+                        // xunit.assert wasn't found - fail quietly so that next check can continue
+                    }
+                }
+            }
+
             return AppDomain
                     .CurrentDomain
                     .GetAssemblies()


### PR DESCRIPTION
attempts to load xunit.assert into app domain if xunit.core is in the app domain and xunit.assert is not