### PR TITLE
Improve end of line support

### DIFF
--- a/ApprovalTests.AppConfig/AppConfigReporter.cs
+++ b/ApprovalTests.AppConfig/AppConfigReporter.cs
@@ -25,8 +25,11 @@ namespace ApprovalTests.Reporters
 
         public void Report(string approved, string received)
         {
+            Reporter.ShouldIgnoreLineEndings = ShouldIgnoreLineEndings;
             Reporter.Report(approved, received);
         }
+
+        public bool ShouldIgnoreLineEndings { get; set; }
 
 
         private IApprovalFailureReporter CreateReporter()

--- a/ApprovalTests.Tests/CleanupReporter.cs
+++ b/ApprovalTests.Tests/CleanupReporter.cs
@@ -10,6 +10,8 @@ namespace ApprovalTests.Tests
             File.Delete(received);
         }
 
+        public bool ShouldIgnoreLineEndings { get; set; }
+
         public bool ApprovedWhenReported()
         {
             return false;

--- a/ApprovalTests.Tests/Reporters/ApprovalTestReporterTest.cs
+++ b/ApprovalTests.Tests/Reporters/ApprovalTestReporterTest.cs
@@ -1,0 +1,40 @@
+﻿using ApprovalTests.Reporters;
+using ApprovalUtilities.Utilities;
+using NUnit.Framework;
+
+namespace ApprovalTests.Tests.Reporters
+{
+    public class ApprovalTestReporterTest
+    {
+        [Test]
+        public void TestApprovalTestIsWorkingForText()
+        {
+            Approvals.SetCaller();
+            Assert.True(ApprovalTestReporter.INSTANCE.IsWorkingInThisEnvironment("default.txt"));
+        }
+        [Test]
+        public void TestApprovalTestIsNotWorkingForImage()
+        {
+            Approvals.SetCaller();
+            Assert.False(ApprovalTestReporter.INSTANCE.IsWorkingInThisEnvironment("default.png"));
+        }
+
+        [Test]
+        public void TestApprovalTestReporterIsWorkingWithEqualsStrings()
+        {
+            ApprovalTestReporter.INSTANCE.ShouldIgnoreLineEndings = true;
+            Assert.DoesNotThrow(() =>ApprovalTestReporter.INSTANCE.Report("Hello", "Hello"));
+        }
+
+        [Test]
+        public void TestApprovalTestReporterIsDetectingNotEqualStrings()
+        {
+            var e = ExceptionUtilities.GetException(() => ApprovalTestReporter.INSTANCE.Report("Hello", "Hello2"));
+            Assert.AreEqual(@"The string are not equal
+               ↓ (pos 5)
+Expected: Hello
+Actual:   Hello2
+               ↑ (pos 5)", e.Message);
+        }
+    }
+}

--- a/ApprovalTests.Tests/Reporters/ApprovalTestReporterTest.cs
+++ b/ApprovalTests.Tests/Reporters/ApprovalTestReporterTest.cs
@@ -36,5 +36,24 @@ Expected: Hello
 Actual:   Hello2
                ↑ (pos 5)", e.Message);
         }
+
+        [Test]
+        public void TestApprovalTestReporterIgnoreEndLines()
+        {
+            ApprovalTestReporter.INSTANCE.ShouldIgnoreLineEndings = true;
+            Assert.DoesNotThrow(() =>ApprovalTestReporter.INSTANCE.Report("Hello\nHello", "Hello\r\nHello"));
+        }
+
+        [Test]
+        public void TestApprovalTestReporterIgnoreEndLinesAndFailAfter()
+        {
+            ApprovalTestReporter.INSTANCE.ShouldIgnoreLineEndings = true;
+            var e = ExceptionUtilities.GetException(() => ApprovalTestReporter.INSTANCE.Report("Hello\nHello", "Hello\r\nHello2"));
+            Assert.AreEqual(@"The string are not equal
+                      ↓ (pos 11)
+Expected: Hello\nHello
+Actual:   Hello\r\nHello2
+                        ↑ (pos 12)", e.Message);
+        }
     }
 }

--- a/ApprovalTests.Tests/Reporters/FirstWorkingReporterTest.cs
+++ b/ApprovalTests.Tests/Reporters/FirstWorkingReporterTest.cs
@@ -50,6 +50,8 @@ namespace ApprovalTests.Tests.Reporters
         {
         }
 
+        public bool ShouldIgnoreLineEndings { get; set; }
+
         public bool IsWorkingInThisEnvironment(string forFile)
         {
             return false;

--- a/ApprovalTests.Tests/Reporters/RecordingReporter.cs
+++ b/ApprovalTests.Tests/Reporters/RecordingReporter.cs
@@ -21,6 +21,8 @@ namespace ApprovalTests.Tests.Reporters
             CalledWith = $"{approved},{received}";
         }
 
+        public bool ShouldIgnoreLineEndings { get; set; }
+
         public bool IsWorkingInThisEnvironment(string forFile)
         {
             return working;

--- a/ApprovalTests.Tests/Reporters/ReporterFactoryTest.cs
+++ b/ApprovalTests.Tests/Reporters/ReporterFactoryTest.cs
@@ -67,6 +67,8 @@ namespace ApprovalTests.Tests.Reporters
         public void Report(string approved, string received)
         {
         }
+
+        public bool ShouldIgnoreLineEndings { get; set; }
     }
 
     public class ClassLevelReporter : IApprovalFailureReporter
@@ -74,5 +76,7 @@ namespace ApprovalTests.Tests.Reporters
         public void Report(string approved, string received)
         {
         }
+
+        public bool ShouldIgnoreLineEndings { get; set; }
     }
 }

--- a/ApprovalTests.Xunit2/Reporters/NonNUnitReporterTest.TestXunitReporterIgnoreEndLinesAndFailAfter.approved.txt
+++ b/ApprovalTests.Xunit2/Reporters/NonNUnitReporterTest.TestXunitReporterIgnoreEndLinesAndFailAfter.approved.txt
@@ -1,0 +1,5 @@
+﻿Assert.Equal() Failure
+                      ↓ (pos 11)
+Expected: Hello\nHello
+Actual:   Hello\r\nHello2
+                        ↑ (pos 12)

--- a/ApprovalTests.Xunit2/Reporters/NonNUnitReporterTest.cs
+++ b/ApprovalTests.Xunit2/Reporters/NonNUnitReporterTest.cs
@@ -28,5 +28,20 @@ namespace ApprovalTests.Xunit2.Reporters
             var e = ExceptionUtilities.GetException(() => XUnit2Reporter.INSTANCE.AssertEqual("Hello", "Hello2"));
             Approvals.Verify(e.Message);
         }
+
+        [Fact]
+        public void TestXunitReporterIgnoreEndLines()
+        {
+            XUnit2Reporter.INSTANCE.ShouldIgnoreLineEndings = true;
+            XUnit2Reporter.INSTANCE.AssertEqual("Hello\nHello", "Hello\r\nHello");
+        }
+
+        [Fact]
+        public void TestXunitReporterIgnoreEndLinesAndFailAfter()
+        {
+            XUnit2Reporter.INSTANCE.ShouldIgnoreLineEndings = true;
+            var e = ExceptionUtilities.GetException(() => XUnit2Reporter.INSTANCE.AssertEqual("Hello\nHello", "Hello\r\nHello2"));
+            Approvals.Verify(e.Message);
+        }
     }
 }

--- a/ApprovalTests/AlwaysWorksReporter.cs
+++ b/ApprovalTests/AlwaysWorksReporter.cs
@@ -17,6 +17,11 @@ namespace ApprovalTests
             reporter.Report(approved, received);
         }
 
+        public bool ShouldIgnoreLineEndings
+        {
+            set => reporter.ShouldIgnoreLineEndings = value;
+        }
+
         public bool IsWorkingInThisEnvironment(string forFile)
         {
             return true;

--- a/ApprovalTests/Approvals.cs
+++ b/ApprovalTests/Approvals.cs
@@ -46,6 +46,7 @@ namespace ApprovalTests
             var normalizeLineEndingsForTextFiles = CurrentCaller.GetFirstFrameForAttribute<IgnoreLineEndingsAttribute>();
             var shouldIgnoreLineEndings = normalizeLineEndingsForTextFiles == null || normalizeLineEndingsForTextFiles.IgnoreLineEndings;
             var approver = GetDefaultApprover(writer, namer, shouldIgnoreLineEndings);
+            reporter.ShouldIgnoreLineEndings = shouldIgnoreLineEndings;
             Verify(approver, reporter);
         }
 

--- a/ApprovalTests/Asserts/StringAssert.cs
+++ b/ApprovalTests/Asserts/StringAssert.cs
@@ -1,0 +1,131 @@
+﻿namespace ApprovalTests.Asserts
+{
+    public class StringAssert
+    {
+        /// <summary>
+        /// Verifies that two strings are equivalent.
+        /// </summary>
+        /// <param name="expected">The expected string value.</param>
+        /// <param name="actual">The actual string value.</param>
+        /// <exception cref="StringEqualException">Thrown when the strings are not equivalent.</exception>
+        public static void Equal(string expected, string actual)
+        {
+            Equal(expected, actual, false);
+        }
+
+        /// <summary>
+        /// Verifies that two strings are equivalent.
+        /// </summary>
+        /// <param name="expected">The expected string value.</param>
+        /// <param name="actual">The actual string value.</param>
+        /// <param name="ignoreCase">If set to <c>true</c>, ignores cases differences. The invariant culture is used.</param>
+        /// <param name="ignoreLineEndingDifferences">If set to <c>true</c>, treats \r\n, \r, and \n as equivalent.</param>
+        /// <param name="ignoreWhiteSpaceDifferences">If set to <c>true</c>, treats spaces and tabs (in any non-zero quantity) as equivalent.</param>
+        /// <exception cref="StringEqualException">Thrown when the strings are not equivalent.</exception>
+        public static void Equal(string expected, string actual, bool ignoreCase = false, bool ignoreLineEndingDifferences = false, bool ignoreWhiteSpaceDifferences = false)
+        {
+            // Start out assuming the one of the values is null
+            var expectedIndex = -1;
+            var actualIndex = -1;
+            var expectedLength = 0;
+            var actualLength = 0;
+
+            if (expected == null)
+            {
+                if (actual == null)
+                    return;
+            }
+            else if (actual != null)
+            {
+                // Walk the string, keeping separate indices since we can skip variable amounts of
+                // data based on ignoreLineEndingDifferences and ignoreWhiteSpaceDifferences.
+                expectedIndex = 0;
+                actualIndex = 0;
+                expectedLength = expected.Length;
+                actualLength = actual.Length;
+
+                while (expectedIndex < expectedLength && actualIndex < actualLength)
+                {
+                    var expectedChar = expected[expectedIndex];
+                    var actualChar = actual[actualIndex];
+
+                    if (ignoreLineEndingDifferences && IsLineEnding(expectedChar) && IsLineEnding(actualChar))
+                    {
+                        expectedIndex = SkipLineEnding(expected, expectedIndex);
+                        actualIndex = SkipLineEnding(actual, actualIndex);
+                    }
+                    else if (ignoreWhiteSpaceDifferences && IsWhiteSpace(expectedChar) && IsWhiteSpace(actualChar))
+                    {
+                        expectedIndex = SkipWhitespace(expected, expectedIndex);
+                        actualIndex = SkipWhitespace(actual, actualIndex);
+                    }
+                    else
+                    {
+                        if (ignoreCase)
+                        {
+                            expectedChar = char.ToUpperInvariant(expectedChar);
+                            actualChar = char.ToUpperInvariant(actualChar);
+                        }
+
+                        if (expectedChar != actualChar)
+                        {
+                            break;
+                        }
+
+                        expectedIndex++;
+                        actualIndex++;
+                    }
+                }
+            }
+
+            if (expectedIndex < expectedLength || actualIndex < actualLength)
+            {
+                throw new StringEqualException(expected, actual, expectedIndex, actualIndex);
+            }
+        }
+
+        static bool IsLineEnding(char c)
+        {
+            return c == '\r' || c == '\n';
+        }
+
+        static bool IsWhiteSpace(char c)
+        {
+            return c == ' ' || c == '\t';
+        }
+
+        static int SkipLineEnding(string value, int index)
+        {
+            if (value[index] == '\r')
+            {
+                ++index;
+            }
+
+            if (index < value.Length && value[index] == '\n')
+            {
+                ++index;
+            }
+
+            return index;
+        }
+
+        static int SkipWhitespace(string value, int index)
+        {
+            while (index < value.Length)
+            {
+                switch (value[index])
+                {
+                    case ' ':
+                    case '\t':
+                        index++;
+                        break;
+
+                    default:
+                        return index;
+                }
+            }
+
+            return index;
+        }
+    }
+}

--- a/ApprovalTests/Asserts/StringEqualException.cs
+++ b/ApprovalTests/Asserts/StringEqualException.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace ApprovalTests.Asserts
+{
+    public class StringEqualException : Exception
+    {
+        static readonly Dictionary<char, string> Encodings = new Dictionary<char, string>
+        {
+            {'\r', "\\r"},
+            {'\n', "\\n"},
+            {'\t', "\\t"},
+            {'\0', "\\0"}
+        };
+
+        /// <summary>
+        /// Gets the actual value.
+        /// </summary>
+        public string Actual { get; }
+
+        /// <summary>
+        /// Gets the expected value.
+        /// </summary>
+        public string Expected { get; }
+
+        private string message;
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="StringEqualException"/> class for string comparisons.
+        /// </summary>
+        /// <param name="expected">The expected string value</param>
+        /// <param name="actual">The actual string value</param>
+        /// <param name="expectedIndex">The first index in the expected string where the strings differ</param>
+        /// <param name="actualIndex">The first index in the actual string where the strings differ</param>
+        public StringEqualException(string expected, string actual, int expectedIndex, int actualIndex)
+        {
+            Actual = actual;
+            ActualIndex = actualIndex;
+            Expected = expected;
+            ExpectedIndex = expectedIndex;
+        }
+
+        private string UserMessage => "The string are not equal";
+
+        /// <summary>
+        /// Gets the index into the actual value where the values first differed.
+        /// Returns -1 if the difference index points were not provided.
+        /// </summary>
+        public int ActualIndex { get; }
+
+        /// <summary>
+        /// Gets the index into the expected value where the values first differed.
+        /// Returns -1 if the difference index points were not provided.
+        /// </summary>
+        public int ExpectedIndex { get; }
+
+        /// <inheritdoc/>
+        public override string Message => message ?? (message = CreateMessage());
+
+        string CreateMessage()
+        {
+            if (ExpectedIndex == -1)
+                return base.Message;
+
+            var printedExpected = ShortenAndEncode(Expected, ExpectedIndex, '↓');
+            var printedActual = ShortenAndEncode(Actual, ActualIndex, '↑');
+
+            return string.Format(
+                CultureInfo.CurrentCulture,
+                "{1}{0}          {2}{0}Expected: {3}{0}Actual:   {4}{0}          {5}",
+                Environment.NewLine,
+                UserMessage,
+                printedExpected.Item2,
+                printedExpected.Item1 ?? "(null)",
+                printedActual.Item1 ?? "(null)",
+                printedActual.Item2
+            );
+        }
+
+        static Tuple<string, string> ShortenAndEncode(string value, int position, char pointer)
+        {
+            var start = Math.Max(position - 20, 0);
+            var end = Math.Min(position + 41, value.Length);
+            var printedValue = new StringBuilder(100);
+            var printedPointer = new StringBuilder(100);
+
+            if (start > 0)
+            {
+                printedValue.Append("···");
+                printedPointer.Append("   ");
+            }
+
+            for (var idx = start; idx < end; ++idx)
+            {
+                var c = value[idx];
+                var paddingLength = 1;
+
+                if (Encodings.TryGetValue(c, out var encoding))
+                {
+                    printedValue.Append(encoding);
+                    paddingLength = encoding.Length;
+                }
+                else
+                    printedValue.Append(c);
+
+                if (idx < position)
+                    printedPointer.Append(' ', paddingLength);
+                else if (idx == position)
+                    printedPointer.AppendFormat("{0} (pos {1})", pointer, position);
+            }
+
+            if (value.Length == position)
+                printedPointer.AppendFormat("{0} (pos {1})", pointer, position);
+
+            if (end < value.Length)
+                printedValue.Append("···");
+
+            return new Tuple<string, string>(printedValue.ToString(), printedPointer.ToString());
+        }
+    }
+}

--- a/ApprovalTests/Core/IApprovalReporter.cs
+++ b/ApprovalTests/Core/IApprovalReporter.cs
@@ -4,5 +4,7 @@ namespace ApprovalTests.Core
     public interface IApprovalFailureReporter
     {
         void Report(string approved, string received);
+        bool ShouldIgnoreLineEndings { set; }
+
     }
 }

--- a/ApprovalTests/Reporters/AllFailingTestsClipboardReporter.cs
+++ b/ApprovalTests/Reporters/AllFailingTestsClipboardReporter.cs
@@ -15,5 +15,7 @@ namespace ApprovalTests.Reporters
             TOTAL.AppendLine(temp);
             Clipboard.SetText(TOTAL.ToString());
         }
+
+        public bool ShouldIgnoreLineEndings { get; set; }
     }
 }

--- a/ApprovalTests/Reporters/AppVeyorReporter.cs
+++ b/ApprovalTests/Reporters/AppVeyorReporter.cs
@@ -9,8 +9,10 @@ namespace ApprovalTests.Reporters
 
         public void Report(string approved, string received)
         {
-            ContinousDeliveryUtils.ReportOnServer(approved,received);
+            ContinousDeliveryUtils.ReportOnServer(approved,received, ShouldIgnoreLineEndings);
         }
+
+        public bool ShouldIgnoreLineEndings { get; set; }
 
         public bool IsWorkingInThisEnvironment(string forFile)
         {

--- a/ApprovalTests/Reporters/ApprovalTestReporter.cs
+++ b/ApprovalTests/Reporters/ApprovalTestReporter.cs
@@ -12,7 +12,7 @@ namespace ApprovalTests.Reporters
 
         public void Report(string approved, string received)
         {
-            StringAssert.Equal(approved, received);
+            StringAssert.Equal(approved, received, false, ShouldIgnoreLineEndings);
         }
 
         public bool ShouldIgnoreLineEndings { get; set; }

--- a/ApprovalTests/Reporters/ApprovalTestReporter.cs
+++ b/ApprovalTests/Reporters/ApprovalTestReporter.cs
@@ -15,6 +15,8 @@ namespace ApprovalTests.Reporters
             StringAssert.Equal(approved, received);
         }
 
+        public bool ShouldIgnoreLineEndings { get; set; }
+
         public bool IsWorkingInThisEnvironment(string forFile)
         {
             return GenericDiffReporter.IsTextFile(forFile);

--- a/ApprovalTests/Reporters/ApprovalTestReporter.cs
+++ b/ApprovalTests/Reporters/ApprovalTestReporter.cs
@@ -1,0 +1,23 @@
+using ApprovalTests.Asserts;
+using ApprovalTests.Core;
+
+namespace ApprovalTests.Reporters
+{
+    /// <summary>
+    /// Reporter that work for string assertion without the need of an assert framework
+    /// </summary>
+    public class ApprovalTestReporter : IEnvironmentAwareReporter
+    {
+        public static readonly ApprovalTestReporter INSTANCE = new ApprovalTestReporter();
+
+        public void Report(string approved, string received)
+        {
+            StringAssert.Equal(approved, received);
+        }
+
+        public bool IsWorkingInThisEnvironment(string forFile)
+        {
+            return GenericDiffReporter.IsTextFile(forFile);
+        }
+    }
+}

--- a/ApprovalTests/Reporters/AssertReporter.cs
+++ b/ApprovalTests/Reporters/AssertReporter.cs
@@ -3,6 +3,7 @@ using ApprovalTests.Namers.StackTraceParsers;
 using System;
 using System.IO;
 using System.Reflection;
+using ApprovalTests.Asserts;
 
 namespace ApprovalTests.Reporters
 {
@@ -51,6 +52,10 @@ namespace ApprovalTests.Reporters
                 var type = Type.GetType(assertClass);
                 var parameters = new[] { approvedContent, receivedContent };
                 InvokeEqualsMethod(type, parameters);
+            }
+            catch (NullReferenceException)
+            {
+                StringAssert.Equal(approvedContent, receivedContent);
             }
             catch (TargetInvocationException e)
             {

--- a/ApprovalTests/Reporters/AssertReporter.cs
+++ b/ApprovalTests/Reporters/AssertReporter.cs
@@ -55,7 +55,7 @@ namespace ApprovalTests.Reporters
             }
             catch (NullReferenceException)
             {
-                StringAssert.Equal(approvedContent, receivedContent);
+                StringAssert.Equal(approvedContent, receivedContent, false, ShouldIgnoreLineEndings);
             }
             catch (TargetInvocationException e)
             {

--- a/ApprovalTests/Reporters/AssertReporter.cs
+++ b/ApprovalTests/Reporters/AssertReporter.cs
@@ -68,5 +68,7 @@ namespace ApprovalTests.Reporters
             var bindingFlags = BindingFlags.InvokeMethod | BindingFlags.Public | BindingFlags.Static;
             type.InvokeMember(areEqual, bindingFlags, null, null, parameters);
         }
+
+        public bool ShouldIgnoreLineEndings { get; set; }
     }
 }

--- a/ApprovalTests/Reporters/BambooReporter.cs
+++ b/ApprovalTests/Reporters/BambooReporter.cs
@@ -9,8 +9,10 @@ namespace ApprovalTests.Reporters
 
         public void Report(string approved, string received)
         {
-            ContinousDeliveryUtils.ReportOnServer(approved, received);
+            ContinousDeliveryUtils.ReportOnServer(approved, received, ShouldIgnoreLineEndings);
         }
+
+        public bool ShouldIgnoreLineEndings { get; set; }
 
         public bool IsWorkingInThisEnvironment(string forFile)
         {

--- a/ApprovalTests/Reporters/ClipboardReporter.cs
+++ b/ApprovalTests/Reporters/ClipboardReporter.cs
@@ -12,5 +12,7 @@ namespace ApprovalTests.Reporters
             var text = QuietReporter.GetCommandLineForApproval(approved, received);
             Clipboard.SetText(text);
         }
+
+        public bool ShouldIgnoreLineEndings { get; set; }
     }
 }

--- a/ApprovalTests/Reporters/ContinousDeliveryUtils.cs
+++ b/ApprovalTests/Reporters/ContinousDeliveryUtils.cs
@@ -2,9 +2,11 @@ namespace ApprovalTests.Reporters
 {
     public class ContinousDeliveryUtils
     {
-        public static void ReportOnServer(string approved, string received)
+        public static void ReportOnServer(string approved, string received, bool shouldIgnoreLineEndings)
         {
             var reporter = FrameworkAssertReporter.INSTANCE;
+            reporter.ShouldIgnoreLineEndings = shouldIgnoreLineEndings;
+
             if (reporter.IsWorkingInThisEnvironment(received))
             {
                 reporter.Report(approved, received);

--- a/ApprovalTests/Reporters/CruiseControlNetReporter.cs
+++ b/ApprovalTests/Reporters/CruiseControlNetReporter.cs
@@ -9,8 +9,10 @@ namespace ApprovalTests.Reporters
 
         public void Report(string approved, string received)
         {
-            ContinousDeliveryUtils.ReportOnServer(approved, received);
+            ContinousDeliveryUtils.ReportOnServer(approved, received, ShouldIgnoreLineEndings);
         }
+
+        public bool ShouldIgnoreLineEndings { get; set; }
 
         public bool IsWorkingInThisEnvironment(string forFile)
         {

--- a/ApprovalTests/Reporters/ExecutableQueryFailure.cs
+++ b/ApprovalTests/Reporters/ExecutableQueryFailure.cs
@@ -26,6 +26,7 @@ namespace ApprovalTests.Reporters
 
         public void Report(string approved, string received)
         {
+            reporter.ShouldIgnoreLineEndings = ShouldIgnoreLineEndings;
             reporter.Report(approved, received);
 
             var receivedResult = ExecuteQuery(received);
@@ -40,6 +41,8 @@ namespace ApprovalTests.Reporters
             var a = RunQueryAndGetPath(approved, approvedResult);
             reporter.Report(a, r);
         }
+
+        public bool ShouldIgnoreLineEndings { get; set; }
 
         private static string RunQueryAndGetPath(string fileName, QueryResult result)
         {

--- a/ApprovalTests/Reporters/FileLauncherReporter.cs
+++ b/ApprovalTests/Reporters/FileLauncherReporter.cs
@@ -12,5 +12,7 @@ namespace ApprovalTests.Reporters
             QuietReporter.DisplayCommandLineApproval(approved, received);
             Process.Start(received);
         }
+
+        public bool ShouldIgnoreLineEndings { get; set; }
     }
 }

--- a/ApprovalTests/Reporters/FileLauncherWithDelayReporter.cs
+++ b/ApprovalTests/Reporters/FileLauncherWithDelayReporter.cs
@@ -18,4 +18,6 @@ public class FileLauncherWithDelayReporter : IApprovalFailureReporter
         FileLauncherReporter.INSTANCE.Report(approved, received);
         Thread.Sleep(seconds * 1000);
     }
+
+    public bool ShouldIgnoreLineEndings { get; set; }
 }

--- a/ApprovalTests/Reporters/FirstWorkingReporter.cs
+++ b/ApprovalTests/Reporters/FirstWorkingReporter.cs
@@ -31,6 +31,17 @@ namespace ApprovalTests.Reporters
             r.Report(approved, received);
         }
 
+        public bool ShouldIgnoreLineEndings
+        {
+            set
+            {
+                foreach (var reporter in Reporters)
+                {
+                    reporter.ShouldIgnoreLineEndings = value;
+                }
+            }
+        }
+
         public virtual bool IsWorkingInThisEnvironment(string forFile)
         {
             return Reporters.Any(x => x.IsWorkingInThisEnvironment(forFile));

--- a/ApprovalTests/Reporters/FrameworkAssertReporter.cs
+++ b/ApprovalTests/Reporters/FrameworkAssertReporter.cs
@@ -8,7 +8,8 @@ namespace ApprovalTests.Reporters
             : base(MsTestReporter.INSTANCE,
                 NUnitReporter.INSTANCE,
                 XUnit2Reporter.INSTANCE,
-                XUnitReporter.INSTANCE)
+                XUnitReporter.INSTANCE,
+                ApprovalTestReporter.INSTANCE)
         {
         }
     }

--- a/ApprovalTests/Reporters/GenericDiffReporter.cs
+++ b/ApprovalTests/Reporters/GenericDiffReporter.cs
@@ -146,6 +146,8 @@ Received {0} ({1}, {2}, {3})", GetType().Name, diffProgram, argumentsFormat, dif
             LaunchAsync(GetLaunchArguments(approved, received));
         }
 
+        public bool ShouldIgnoreLineEndings { get; set; }
+
         public static void EnsureFileExists(string approved)
         {
             if (!File.Exists(approved))

--- a/ApprovalTests/Reporters/GoContinuousDeliveryReporter.cs
+++ b/ApprovalTests/Reporters/GoContinuousDeliveryReporter.cs
@@ -9,8 +9,10 @@ namespace ApprovalTests.Reporters
 
         public void Report(string approved, string received)
         {
-            ContinousDeliveryUtils.ReportOnServer(approved, received);
+            ContinousDeliveryUtils.ReportOnServer(approved, received, ShouldIgnoreLineEndings);
         }
+
+        public bool ShouldIgnoreLineEndings { get; set; }
 
         public bool IsWorkingInThisEnvironment(string forFile)
         {

--- a/ApprovalTests/Reporters/IntroductionReporter.cs
+++ b/ApprovalTests/Reporters/IntroductionReporter.cs
@@ -16,6 +16,8 @@ namespace ApprovalTests.Reporters
             throw new Exception(message);
         }
 
+        public bool ShouldIgnoreLineEndings { get; set; }
+
         public string GetFriendlyWelcomeMessage()
         {
             var message =

--- a/ApprovalTests/Reporters/InvalidReporterConfiguration.cs
+++ b/ApprovalTests/Reporters/InvalidReporterConfiguration.cs
@@ -17,6 +17,8 @@ namespace ApprovalTests.Reporters
             throw BuildException();
         }
 
+        public bool ShouldIgnoreLineEndings { get; set; }
+
         public bool IsWorkingInThisEnvironment(string forFile)
         {
             throw BuildException();

--- a/ApprovalTests/Reporters/JenkinsReporter.cs
+++ b/ApprovalTests/Reporters/JenkinsReporter.cs
@@ -9,8 +9,10 @@ namespace ApprovalTests.Reporters
 
         public void Report(string approved, string received)
         {
-            ContinousDeliveryUtils.ReportOnServer(approved, received);
+            ContinousDeliveryUtils.ReportOnServer(approved, received, ShouldIgnoreLineEndings);
         }
+
+        public bool ShouldIgnoreLineEndings { get; set; }
 
         public bool IsWorkingInThisEnvironment(string forFile)
         {

--- a/ApprovalTests/Reporters/MightyMooseAutoTestReporter.cs
+++ b/ApprovalTests/Reporters/MightyMooseAutoTestReporter.cs
@@ -13,6 +13,8 @@ namespace ApprovalTests.Reporters
             // do nothing
         }
 
+        public bool ShouldIgnoreLineEndings { get; set; }
+
         public bool IsWorkingInThisEnvironment(string forFile)
         {
             if (IsRunning == null)

--- a/ApprovalTests/Reporters/MultiReporter.cs
+++ b/ApprovalTests/Reporters/MultiReporter.cs
@@ -52,5 +52,16 @@ namespace ApprovalTests.Reporters
                 throw lastThrown;
             }
         }
+
+        public bool ShouldIgnoreLineEndings
+        {
+            set
+            {
+                foreach (var reporter in Reporters)
+                {
+                    reporter.ShouldIgnoreLineEndings = value;
+                }
+            }
+        }
     }
 }

--- a/ApprovalTests/Reporters/MyGetReporter.cs
+++ b/ApprovalTests/Reporters/MyGetReporter.cs
@@ -12,6 +12,8 @@ namespace ApprovalTests.Reporters
             // does nothing
         }
 
+        public bool ShouldIgnoreLineEndings { get; set; }
+
         public bool IsWorkingInThisEnvironment(string forFile)
         {
             return "MyGet".Equals(Environment.GetEnvironmentVariable("BuildRunner"));

--- a/ApprovalTests/Reporters/NCrunchReporter.cs
+++ b/ApprovalTests/Reporters/NCrunchReporter.cs
@@ -12,6 +12,8 @@ namespace ApprovalTests.Reporters
         {
         }
 
+        public bool ShouldIgnoreLineEndings { get; set; }
+
         public bool IsWorkingInThisEnvironment(string forFile)
         {
             var ncrunch = Environment.GetEnvironmentVariable(EnvironmentVariable);

--- a/ApprovalTests/Reporters/NotepadLauncher.cs
+++ b/ApprovalTests/Reporters/NotepadLauncher.cs
@@ -12,5 +12,7 @@ namespace ApprovalTests.Reporters
             QuietReporter.DisplayCommandLineApproval(approved, received);
             Process.Start(received);
         }
+
+        public bool ShouldIgnoreLineEndings { get; set; }
     }
 }

--- a/ApprovalTests/Reporters/PowershellClipboardReporter.cs
+++ b/ApprovalTests/Reporters/PowershellClipboardReporter.cs
@@ -13,6 +13,8 @@ namespace ApprovalTests.Reporters
             Clipboard.SetText(text);
         }
 
+        public bool ShouldIgnoreLineEndings { get; set; }
+
         public static string GetCommandLineForApproval(string approved, string received)
         {
             return $"Move-Item \"{received}\" \"{approved}\" -Force";

--- a/ApprovalTests/Reporters/QuietReporter.cs
+++ b/ApprovalTests/Reporters/QuietReporter.cs
@@ -4,6 +4,9 @@ using ApprovalTests.Core;
 
 namespace ApprovalTests.Reporters
 {
+    /// <summary>
+    /// Reporter that print the command line to accept all the test results
+    /// </summary>
     public class QuietReporter : IEnvironmentAwareReporter
     {
         public static readonly QuietReporter INSTANCE = new QuietReporter();
@@ -12,6 +15,8 @@ namespace ApprovalTests.Reporters
         {
             DisplayCommandLineApproval(approved, received);
         }
+
+        public bool ShouldIgnoreLineEndings { get; set; }
 
         public static void DisplayCommandLineApproval(string approved, string received)
         {

--- a/ApprovalTests/Reporters/ReportWithoutFrontLoading.cs
+++ b/ApprovalTests/Reporters/ReportWithoutFrontLoading.cs
@@ -10,6 +10,8 @@ namespace ApprovalTests.Reporters
             // do nothing
         }
 
+        public bool ShouldIgnoreLineEndings { get; set; }
+
         public bool IsWorkingInThisEnvironment(string forFile)
         {
             return false;

--- a/ApprovalTests/Reporters/TeamCityReporter.cs
+++ b/ApprovalTests/Reporters/TeamCityReporter.cs
@@ -9,8 +9,10 @@ namespace ApprovalTests.Reporters
 
         public void Report(string approved, string received)
         {
-            ContinousDeliveryUtils.ReportOnServer(approved, received);
+            ContinousDeliveryUtils.ReportOnServer(approved, received, ShouldIgnoreLineEndings);
         }
+
+        public bool ShouldIgnoreLineEndings { get; set; }
 
         public bool IsWorkingInThisEnvironment(string forFile)
         {

--- a/ApprovalTests/Reporters/TfsReporter.cs
+++ b/ApprovalTests/Reporters/TfsReporter.cs
@@ -15,8 +15,10 @@ namespace ApprovalTests.Reporters
 
         public void Report(string approved, string received)
         {
-            ContinousDeliveryUtils.ReportOnServer(approved, received);
+            ContinousDeliveryUtils.ReportOnServer(approved, received, ShouldIgnoreLineEndings);
         }
+
+        public bool ShouldIgnoreLineEndings { get; set; }
 
         private static string GetParentProcessName()
         {

--- a/ApprovalTests/Reporters/TfsVnextReporter.cs
+++ b/ApprovalTests/Reporters/TfsVnextReporter.cs
@@ -9,8 +9,10 @@ namespace ApprovalTests.Reporters
 
       public void Report(string approved, string received)
       {
-            ContinousDeliveryUtils.ReportOnServer(approved, received);
+            ContinousDeliveryUtils.ReportOnServer(approved, received, ShouldIgnoreLineEndings);
         }
+
+      public bool ShouldIgnoreLineEndings { get; set; }
 
       public bool IsWorkingInThisEnvironment(string forFile)
       {

--- a/ApprovalTests/Reporters/TortoiseComboImageReporter.cs
+++ b/ApprovalTests/Reporters/TortoiseComboImageReporter.cs
@@ -21,6 +21,8 @@ namespace ApprovalTests.Reporters
             }
         }
 
+        public bool ShouldIgnoreLineEndings { get; set; }
+
         public static bool FileExistsAndNonEmpty(string file)
         {
             var a = new FileInfo(file);

--- a/ApprovalTests/Reporters/XUnit2Reporter.cs
+++ b/ApprovalTests/Reporters/XUnit2Reporter.cs
@@ -1,11 +1,14 @@
 using System;
+using ApprovalTests.Asserts;
 
 namespace ApprovalTests.Reporters
 {
     using System.Linq;
 
     using StackTraceParsers;
-
+    /// <summary>
+    /// Reporter to use when using Xunit >=2
+    /// </summary>
     public class XUnit2Reporter : AssertReporter
     {
         public readonly static XUnit2Reporter INSTANCE = new XUnit2Reporter();
@@ -32,8 +35,29 @@ namespace ApprovalTests.Reporters
 
         protected override void InvokeEqualsMethod(Type type, string[] parameters)
         {
-            var method = type.GetMethods().First(m => m.Name == areEqual && m.GetParameters().Count() == 2);
-            method.Invoke(null, parameters);
+            var xunitAssertMethods = type.GetMethods();
+            var method = xunitAssertMethods.First(m => m.Name == areEqual && m.GetParameters().Count() == 5);
+            if (method != null)
+            {
+                var ignoreEndLineParameters = new object[]
+                {
+                    parameters[0],
+                    parameters[1],
+                    false, //ignoreCase
+                    ShouldIgnoreLineEndings, //ignoreLineEndingDifferences
+                    false //ignoreWhiteSpaceDifferences
+                };
+                method.Invoke(null, ignoreEndLineParameters.ToArray());
+                return;
+            }
+
+            method = xunitAssertMethods.First(m => m.Name == areEqual && m.GetParameters().Count() == 2);
+            if (method != null)
+            {
+                method.Invoke(null, parameters);
+            }
+
+            StringAssert.Equal(parameters[0], parameters[1], false, ShouldIgnoreLineEndings);
         }
     }
 }

--- a/ApprovalTests/Reporters/XUnit2Reporter.cs
+++ b/ApprovalTests/Reporters/XUnit2Reporter.cs
@@ -10,6 +10,7 @@ namespace ApprovalTests.Reporters
     {
         public readonly static XUnit2Reporter INSTANCE = new XUnit2Reporter();
         private static readonly Lazy<bool> isXunit2 = new Lazy<bool>(IsXunit2);
+        public bool ShouldIgnoreLineEndings { get; set; }
 
         private static bool IsXunit2()
         {


### PR DESCRIPTION
* Add (and adapt) string assert from xunit project as a fallback to not be necessarily dependent of loading framework assert libraries (code is is under Apache 2 license, like ApprovalTests, so no problem...)

* And use it as a fallback string assert method when unable to load the assert assembly
That fixes #159
Useful if a project use a different assert library (fluent assertions, shouldly, nfluent,...)
than the one provided by the unit test framework (like xunit2 permit it.)

* Add a reporter that work for string assertion without the need of an assert framework (and which is probably better than a lot of string assert provided by assert from frameworks...)

* Add support of ignoring line ending also in newly added ApprovalTest reporter and xunit2Reporter (a step toward solving #134 )Especially, https://github.com/approvals/ApprovalTests.Net/issues/134#issuecomment-289417510 , that I also had.

PS: It should be easier to review each commit separately....
