### PR TITLE
B    add new error message for if a source path cannot be found

### DIFF
--- a/ApprovalTests.Tests/Namer/NunitStackTraceNamerTests.cs
+++ b/ApprovalTests.Tests/Namer/NunitStackTraceNamerTests.cs
@@ -18,10 +18,10 @@ namespace ApprovalTests.Tests.Namer
         [Test]
         public void TestSourcePath()
         {
-            var name = Approvals.GetDefaultNamer().SourcePath;
-            Assert.IsNotEmpty(name);
-            var path = name.ToLower() + Path.DirectorySeparatorChar + GetType().Name + ".cs";
-            Assert.IsTrue(File.Exists(path), path + " does not exist");
+            var path = Approvals.GetDefaultNamer().SourcePath;
+            Assert.IsNotEmpty(path);
+            var fullPath = path.ToLower() + Path.DirectorySeparatorChar + GetType().Name + ".cs";
+            Assert.IsTrue(File.Exists(fullPath), fullPath + " does not exist");
         }
 
         [Test]

--- a/ApprovalTests/Namers/StackTraceParsers/StackTraceParser.cs
+++ b/ApprovalTests/Namers/StackTraceParsers/StackTraceParser.cs
@@ -54,7 +54,32 @@ To learn how to implement one see {helpLink}")
 
         public string ApprovalName => parser.ApprovalName;
 
-        public string SourcePath => parser.SourcePath;
+        public string SourcePath
+        {
+            get
+            {
+                var path = parser.SourcePath;
+                if (string.IsNullOrEmpty(path))
+                {
+                    var helpMessage = @"
+ApprovalTests is not detecting the proper source path
+
+This is probably because you're missing the following
+line in your .csproj file:
+	  <DebugType>full</DebugType>
+in the 
+<Project>
+  <PropertyGroup>
+element.
+
+Solution:
+a) Add <DebugType>full</DebugType> to your .csproj file.
+b) OR Build->Advanced->DebugInfo to Full";
+                    throw new Exception(helpMessage);
+                }
+                return path;
+            }
+        }
 
         private static void LoadIfApplicable(IList<IStackTraceParser> found, AttributeStackTraceParser p)
         {


### PR DESCRIPTION
Changing from .net standard to full framework with new csproj project requires the <DebugType>full</DebugType>
attribute to be added to the project.