### PR TITLE
B remove redundant DoUpgradeToUTF8Patch

### DIFF
--- a/ApprovalTests.Tests/FileWithUtf8ByteOrderMark.txt
+++ b/ApprovalTests.Tests/FileWithUtf8ByteOrderMark.txt
@@ -1,1 +1,0 @@
-﻿This file DOES have a byte order mark 

--- a/ApprovalTests.Tests/FileWithoutUtf8ByteOrderMark.txt
+++ b/ApprovalTests.Tests/FileWithoutUtf8ByteOrderMark.txt
@@ -1,1 +1,0 @@
-This file does NOT have a byte order mark

--- a/ApprovalTests.Tests/StringEncodingTest.cs
+++ b/ApprovalTests.Tests/StringEncodingTest.cs
@@ -31,14 +31,5 @@ namespace ApprovalTests.Tests
             Approvals.Verify(text);
         }
 #endif
-
-        [Test]
-        public void TestDetectUtf8ByteOrderMark()
-        {
-            var with = PathUtilities.GetAdjacentFile("FileWithUtf8ByteOrderMark.txt");
-            var without = PathUtilities.GetAdjacentFile("FileWithoutUtf8ByteOrderMark.txt");
-            Assert.IsTrue(ApprovalTextWriter.IsUft8ByteOrderMarkPresent(with));
-            Assert.IsFalse(ApprovalTextWriter.IsUft8ByteOrderMarkPresent(without));
-        }
     }
 }

--- a/ApprovalTests/Writers/ApprovalTextWriter.cs
+++ b/ApprovalTests/Writers/ApprovalTextWriter.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 using System.Text;
 using ApprovalTests.Core;
@@ -22,7 +21,6 @@ namespace ApprovalTests
         public string Data { get; set; }
         public string ExtensionWithDot { get; set; }
 
-
         public virtual string GetApprovalFilename(string basename)
         {
             return $"{basename}.approved{ExtensionWithDot}";
@@ -37,64 +35,7 @@ namespace ApprovalTests
         {
             Directory.CreateDirectory(Path.GetDirectoryName(received));
             File.WriteAllText(received, Data, Encoding.UTF8);
-            DoUpgradeToUTF8Patch(received);
             return received;
-        }
-
-        private void DoUpgradeToUTF8Patch(string received)
-        {
-            var approved = received.Replace(".received", ".approved");
-            if (File.Exists(approved) && !IsUft8ByteOrderMarkPresent(approved))
-            {
-                ConsoleUtilities.WriteLine($"Upgrading {approved} to include Utf8 Byte Order Mark. (this is a 1 time event)");
-                var text = File.ReadAllText(approved);
-                File.WriteAllText(approved, text, Encoding.UTF8);
-            }
-        }
-
-        public static bool IsUft8ByteOrderMarkPresent(string file)
-        {
-            var preamble = Encoding.UTF8.GetPreamble();
-            var readAllBytes = ReadBytes(file, preamble.Length);
-            if (readAllBytes.Length < preamble.Length)
-            {
-                return false;
-            }
-
-            for (var i = 0; i < preamble.Length; i++)
-            {
-                if (preamble[i] != readAllBytes[i])
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-        private static byte[] ReadBytes(string file, int length)
-        {
-            byte[] buffer;
-            using (var fileStream = new FileStream(file, FileMode.Open, FileAccess.Read))
-            {
-                var offset = 0;
-                var fileLength = fileStream.Length;
-                var count = (int) Math.Min(length, fileLength);
-                buffer = new byte[count];
-                while (count > 0)
-                {
-                    var num = fileStream.Read(buffer, offset, count);
-                    if (num == 0)
-                    {
-                        throw new Exception("Unexpected End of File while reading " + file);
-                    }
-
-                    offset += num;
-                    count -= num;
-                }
-            }
-
-            return buffer;
         }
     }
 }


### PR DESCRIPTION
given this was 6 years ago https://github.com/approvals/ApprovalTests.Net/commit/d55f3313bbc4e79a7e84866bebe5945c50a9bf0a

and it is meant to be a one time thing. i think we can remove that code.

@isidore thoughts