### PR TITLE
R obsolete StringUtils.JoinWith*

### DIFF
--- a/ApprovalTests/Namers/ApprovalResults.cs
+++ b/ApprovalTests/Namers/ApprovalResults.cs
@@ -126,8 +126,7 @@ https://github.com/approvals/ApprovalTests.Net/issues/new?title=Unknown%3A+%27Ru
 
         public static IDisposable ForScenario(params object[] dataPoints)
         {
-            var name = dataPoints.JoinStringsWith(o => "" + o, ".");
-            return ForScenario(name);
+            return ForScenario(string.Join(".", dataPoints));
         }
 
         public static string Scrub(string data)

--- a/ApprovalTests/TheoryTests/ThreadSafetyTheory.cs
+++ b/ApprovalTests/TheoryTests/ThreadSafetyTheory.cs
@@ -2,7 +2,6 @@
 using System.Collections.Concurrent;
 using System.Linq;
 using ApprovalTests.Utilities;
-using ApprovalUtilities.Utilities;
 
 namespace ApprovalTests.TheoryTests
 {
@@ -51,7 +50,7 @@ namespace ApprovalTests.TheoryTests
 
         private static string ToText<T>(T[] n2, string label2)
         {
-            return label2 + "\n" + n2.JoinStringsWith(t => "" + t, "\n");
+            return $"{label2}\n{string.Join("\n", n2)}";
         }
     }
 }

--- a/ApprovalUtilities/Utilities/StringUtils.cs
+++ b/ApprovalUtilities/Utilities/StringUtils.cs
@@ -160,11 +160,17 @@ namespace ApprovalUtilities.Utilities
             return sb.ToString();
         }
 
+        [ObsoleteEx(
+            RemoveInVersion = "5.0",
+            ReplacementTypeOrMember = "String.Join(string separator, IEnumerable<string> values)")]
         public static string JoinStringsWith<T>(this IEnumerable<T> elements, Func<T, string> transform, string seperator)
         {
-            return JoinWith(elements.Select(transform), seperator);
+            return string.Join(seperator, elements.Select(transform));
         }
 
+        [ObsoleteEx(
+            RemoveInVersion = "5.0",
+            ReplacementTypeOrMember = "String.Join(string separator, IEnumerable<string> values)")]
         public static string JoinWith(this IEnumerable<string> elements, string seperator)
         {
             return string.Join(seperator, elements.ToArray());


### PR DESCRIPTION
All the usages of `StringUtils.JoinWith*` do a simple `ToString` on the input value, rendering `Func<T, string> transform` redundant.