### PR TITLE
Add assembly/namespace convention-based .approved. file resolution

### DIFF
--- a/src/ApprovalTests.Tests/Namer/AssemblyLocationAndTestNamespaceNamerTests.cs
+++ b/src/ApprovalTests.Tests/Namer/AssemblyLocationAndTestNamespaceNamerTests.cs
@@ -1,0 +1,22 @@
+﻿using System.IO;
+using ApprovalTests.Namers;
+using NUnit.Framework;
+
+// ReSharper disable once CheckNamespace
+namespace ApprovalTests.Tests.Namer.With.Additional.Namespace.Nesting
+{
+    public class AssemblyLocationAndTestNamespaceNamerTests
+    {
+        [Test]
+        public void TestSourcePath()
+        {
+            var sourcePath = new AssemblyLocationAndTestNamespaceNamer().SourcePath;
+            var expectedPath =
+                Path.Combine(
+                    new AssemblyLocationNamer().SourcePath,
+                    @"Namer\With\Additional\Namespace\Nesting");
+
+            Assert.AreEqual(expectedPath, sourcePath);
+        }
+    }
+}

--- a/src/ApprovalTests.Tests/Namer/AssemblyLocationAndTestNamespaceNamerTests.cs
+++ b/src/ApprovalTests.Tests/Namer/AssemblyLocationAndTestNamespaceNamerTests.cs
@@ -14,7 +14,7 @@ namespace ApprovalTests.Tests.Namer.With.Additional.Namespace.Nesting
             var expectedPath =
                 Path.Combine(
                     new AssemblyLocationNamer().SourcePath,
-                    @"Namer\With\Additional\Namespace\Nesting");
+                    @"Namer\With\Additional\Namespace\Nesting".Replace(@"\", Path.DirectorySeparatorChar.ToString()));
 
             Assert.AreEqual(expectedPath, sourcePath);
         }

--- a/src/ApprovalTests/Approvals.cs
+++ b/src/ApprovalTests/Approvals.cs
@@ -153,6 +153,7 @@ namespace ApprovalTests
         {
             return defaultNamerCreator.Invoke();
         }
+
         /// <summary>
         /// This is sometimes needed on CI systems that move/remove the original source.
         /// If you use this you will also need to set the .approved. files to "Copy Always"
@@ -161,7 +162,25 @@ namespace ApprovalTests
         /// </summary>
         public static void UseAssemblyLocationForApprovedFiles()
         {
-            RegisterDefaultNamerCreation(()=> new AssemblyLocationNamer());
+            RegisterDefaultNamerCreation(() => new AssemblyLocationNamer());
+        }
+
+        /// <summary>
+        /// This is sometimes needed on CI systems that move/remove the original source.
+        /// If you use this you will also need to set the .approved. files to "Copy Always".
+        ///
+        /// An example of when this is required is:
+        /// * The source location is D:\a\1\s\Foo.Tests\Bar\Baz\Qux.approved.txt
+        /// * The execution location is D:\a\r1\a\Foo.Tests\Bar\Baz\Qux.approved.txt
+        /// * The test namespace is Foo.Tests.Bar.Baz
+        ///
+        /// To use this the following conditions must be met:
+        /// * All test namespaces must start with the test assembly's name
+        /// * All test namespaces must align with the on-disk folder structure
+        /// </summary>
+        public static void UseAssemblyLocationAndTestNamespaceForApprovedFiles()
+        {
+            RegisterDefaultNamerCreation(() => new AssemblyLocationAndTestNamespaceNamer());
         }
 
         public static void Verify(object text)

--- a/src/ApprovalTests/Namers/AssemblyLocationAndTestNamespaceNamer.cs
+++ b/src/ApprovalTests/Namers/AssemblyLocationAndTestNamespaceNamer.cs
@@ -1,0 +1,49 @@
+﻿using System.Diagnostics;
+using System.IO;
+using System.Text.RegularExpressions;
+
+namespace ApprovalTests.Namers
+{
+    /// <summary>
+    /// <see cref="UnitTestFrameworkNamer" /> assumes that the .approved. files exist relative to the original source location (which is derived from <see cref="StackFrame.GetFileName" />).
+    /// The issue with this assumption is that the test execution location may, in some cases, differ to the test source location.
+    ///
+    /// As a concrete example:
+    /// * The source location is D:\a\1\s\Foo.Tests\Bar\Baz\Qux.approved.txt
+    /// * The execution location is D:\a\r1\a\Foo.Tests\Bar\Baz\Qux.approved.txt
+    /// * The test namespace is Foo.Tests.Bar.Baz
+    ///
+    /// In this example D:\a\1\s\Foo.Tests\Bar\Baz\Qux.approved.txt would not be found (resulting in the test actual being compared against "").
+    ///
+    /// This Namer resolves this, with the following conditions:
+    /// * All test namespaces must start with the test assembly's name. e.g. Foo.Tests
+    /// * All test namespaces must align with the on-disk folder structure. e.g. The Foo.Tests.Bar.Baz namespace must be stored on disk as Foo.Tests\Bar\Baz
+    /// </summary>
+    public class AssemblyLocationAndTestNamespaceNamer : AssemblyLocationNamer
+    {
+        public AssemblyLocationAndTestNamespaceNamer()
+        {
+        }
+
+        public override string SourcePath => Path.Combine(AssemblyDirectory, GetSubDirectoryFromTestNamespace());
+
+        private string GetSubDirectoryFromTestNamespace()
+        {
+            // e.g. Foo.Tests.Bar.Baz
+            var testNamespace = ApprovalClass.Namespace;
+
+            // e.g. Foo.Tests
+            var testAssemblyName = ApprovalClass.Assembly.GetName().Name;
+            var expectedNamespacePrefixRegex = $"^{testAssemblyName}[.]";
+
+            // e.g. Replace Foo.Tests.Bar.Baz with Bar.Baz
+            var testNamespaceWithoutAssemblyName =
+                Regex.Replace(testNamespace, expectedNamespacePrefixRegex, "");
+
+            // e.g. Replace Bar.Baz with Bar\Baz
+            var subDirectory = testNamespaceWithoutAssemblyName.Replace(".", Path.DirectorySeparatorChar.ToString());
+
+            return subDirectory;
+        }
+    }
+}

--- a/src/ApprovalTests/Namers/AssemblyLocationNamer.cs
+++ b/src/ApprovalTests/Namers/AssemblyLocationNamer.cs
@@ -6,7 +6,7 @@ namespace ApprovalTests.Namers
 {
     public class AssemblyLocationNamer : UnitTestFrameworkNamer
     {
-        private string AssemblyDirectory
+        protected string AssemblyDirectory
         {
             get
             {

--- a/src/ApprovalTests/Namers/StackTraceParsers/AttributeStackTraceParser.cs
+++ b/src/ApprovalTests/Namers/StackTraceParsers/AttributeStackTraceParser.cs
@@ -29,6 +29,7 @@ namespace ApprovalTests.Namers.StackTraceParsers
         }
 
         public string ApprovalName => $"{TypeName}.{GetMethodName()}{AdditionalInfo}";
+        public Type ApprovalClass => approvalFrame.Class;
 
         protected virtual string GetMethodName()
         {

--- a/src/ApprovalTests/Namers/StackTraceParsers/IStackTraceParser.cs
+++ b/src/ApprovalTests/Namers/StackTraceParsers/IStackTraceParser.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics;
 
 namespace ApprovalTests.Namers.StackTraceParsers
@@ -5,6 +6,7 @@ namespace ApprovalTests.Namers.StackTraceParsers
     public interface IStackTraceParser
     {
         string ApprovalName { get; }
+        Type ApprovalClass { get; }
         string SourcePath { get; }
         string ForTestingFramework { get; }
         bool Parse(StackTrace stackTrace);

--- a/src/ApprovalTests/Namers/StackTraceParsers/StackTraceParser.cs
+++ b/src/ApprovalTests/Namers/StackTraceParsers/StackTraceParser.cs
@@ -54,6 +54,8 @@ To learn how to implement one see {helpLink}")
 
         public string ApprovalName => parser.ApprovalName;
 
+        public Type ApprovalClass => parser.ApprovalClass;
+
         public string SourcePath
         {
             get

--- a/src/ApprovalTests/Namers/UnitTestFrameworkNamer.cs
+++ b/src/ApprovalTests/Namers/UnitTestFrameworkNamer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using ApprovalTests.Core;
 using ApprovalTests.Namers.StackTraceParsers;
@@ -24,6 +25,8 @@ namespace ApprovalTests.Namers
         }
 
         public string Name => stackTraceParser.ApprovalName;
+
+        protected Type ApprovalClass => stackTraceParser.ApprovalClass;
 
         public virtual string SourcePath => Path.Combine(stackTraceParser.SourcePath, Subdirectory);
 


### PR DESCRIPTION
## Description

Adds improved support for scenarios where the test execution location differs to the test source location. For example, when running tests on a different machine or folder.

## The solution

This introduces `AssemblyLocationAndTestNamespaceNamer`, which builds assembly/namespace convention-based .approved. file resolution on top of `AssemblyLocationNamer`. It is enabled through `Approvals.UseAssemblyLocationAndTestNamespaceForApprovedFiles()`.

All changes are additive other than,
- `AssemblyLocationNamer.AssemblyDirectory`, which was changed from `private` to `protected`.
- `IStackTraceParser.ApprovalClass`. It looks like all `StackTraceParser*` implementations inherit from `AttributeStackTraceParser`... are there any custom implementations that don't? Could this potentially break any users?

