### PR TITLE
fixed issue with static instance initialisation

### DIFF
--- a/src/ApprovalTests/Reporters/Windows/RiderReporter.cs
+++ b/src/ApprovalTests/Reporters/Windows/RiderReporter.cs
@@ -7,7 +7,7 @@ namespace ApprovalTests.Reporters.Windows
 {
     public class RiderReporter : GenericDiffReporter
     {
-        public static readonly RiderReporter INSTANCE = new RiderReporter();
+        public static readonly RiderReporter INSTANCE;
         private static string PATH;
 
         static RiderReporter()
@@ -20,6 +20,8 @@ namespace ApprovalTests.Reporters.Windows
             {
                 PATH = null;
             }
+            
+            INSTANCE = new RiderReporter();
         }
 
         public RiderReporter()


### PR DESCRIPTION
## Description

When running approval tests from Jetbrains Rider on Windows, the `RiderReporter` always yields "Not launched from Rider.". Some debugging shows me that the order of initialization of the `PATH` and `INSTANCE` are the cause.

## The solution

Make sure that the static `PATH` field is initialized first.

