### PR TITLE
Approvals.AssertText(expected, actual) to support 'actual' as arrays

### DIFF
--- a/docs/ApprovalTests/Features.md
+++ b/docs/ApprovalTests/Features.md
@@ -27,11 +27,11 @@ Sample:
 <a id='snippet-assert_text_before'/></a>
 ```cs
 var header = new Header();
-var actual = header.MakeHeading("I am ten chars");
+var actual = header.MakeHeading("I am a heading");
 var expected = "";
 Approvals.AssertText(expected, actual);
 ```
-<sup><a href='/src/ApprovalTests.Tests/Reporters/InlineTextReporterTest.cs#L54-L59' title='File snippet `assert_text_before` was extracted from'>snippet source</a> | <a href='#snippet-assert_text_before' title='Navigate to start of snippet `assert_text_before`'>anchor</a></sup>
+<sup><a href='/src/ApprovalTests.Tests/Reporters/InlineTextReporterTest.cs#L68-L73' title='File snippet `assert_text_before` was extracted from'>snippet source</a> | <a href='#snippet-assert_text_before' title='Navigate to start of snippet `assert_text_before`'>anchor</a></sup>
 <!-- endsnippet -->
 
 When you do this, it will copy the c# for the `.recieved.` to your clipboard, so you can paste it inline.
@@ -41,20 +41,19 @@ When you do this, it will copy the c# for the `.recieved.` to your clipboard, so
 <a id='snippet-assert_text'/></a>
 ```cs
 var header = new Header();
-var actual = header.MakeHeading("I am ten chars");
+var actual = header.MakeHeading("I am a heading");
 var expected = new[]{
     "**************",
-    "I am ten chars",
+    "I am a heading",
     "**************",
-
 };
 Approvals.AssertText(expected, actual);
 ```
-<sup><a href='/src/ApprovalTests.Tests/Reporters/InlineTextReporterTest.cs#L39-L49' title='File snippet `assert_text` was extracted from'>snippet source</a> | <a href='#snippet-assert_text' title='Navigate to start of snippet `assert_text`'>anchor</a></sup>
+<sup><a href='/src/ApprovalTests.Tests/Reporters/InlineTextReporterTest.cs#L38-L47' title='File snippet `assert_text` was extracted from'>snippet source</a> | <a href='#snippet-assert_text' title='Navigate to start of snippet `assert_text`'>anchor</a></sup>
 <!-- endsnippet -->
 
 
-Currently, it put the text as an array of strings that gets concatenated as this tends to read better.
+Currently, it put the text as an array of strings that gets concatenated as this tends to read better. Actual can be a string, or an array of strings.
 
 It will also write the results to a temp files on failure and open a DiffTool, so you can easily view the results and differences.
 

--- a/docs/ApprovalTests/mdsource/Features.source.md
+++ b/docs/ApprovalTests/mdsource/Features.source.md
@@ -17,7 +17,7 @@ When you do this, it will copy the c# for the `.recieved.` to your clipboard, so
 snippet: assert_text
 
 
-Currently, it put the text as an array of strings that gets concatenated as this tends to read better.
+Currently, it put the text as an array of strings that gets concatenated as this tends to read better. Actual can be a string, or an array of strings.
 
 It will also write the results to a temp files on failure and open a DiffTool, so you can easily view the results and differences.
 

--- a/src/ApprovalTests.Tests/Reporters/InlineTextReporterTest.CSharpStrings.approved.txt
+++ b/src/ApprovalTests.Tests/Reporters/InlineTextReporterTest.CSharpStrings.approved.txt
@@ -4,6 +4,6 @@ var expected = "boo";
 var expected = "with \"quotes\".";
                 var expected = new[]{
                 "**************",
-                "I am ten chars",
+                "I am a heading",
                 "**************",
                 };

--- a/src/ApprovalTests.Tests/Reporters/InlineTextReporterTest.cs
+++ b/src/ApprovalTests.Tests/Reporters/InlineTextReporterTest.cs
@@ -24,8 +24,7 @@ namespace ApprovalTests.Tests.Reporters
             var example1 = new[]
             {
                 "**************",
-
-                "I am ten chars",
+                "I am a heading",
                 "**************",
             };
             var samples = new[] { "boo","with \"quotes\".", example1.JoinWith("\n"), };
@@ -34,46 +33,62 @@ namespace ApprovalTests.Tests.Reporters
         }
 
         [Test]
-        public void Makerheadertest()
+        public void AssertTextTest()
         {
             // begin-snippet: assert_text
             var header = new Header();
-            var actual = header.MakeHeading("I am ten chars");
+            var actual = header.MakeHeading("I am a heading");
             var expected = new[]{
                 "**************",
-                "I am ten chars",
+                "I am a heading",
                 "**************",
-
             };
             Approvals.AssertText(expected, actual);
             // end-snippet
         }
 
-        public void MakerheaderBefore()
+        [Test]
+        public void AssertTextArraysTest()
         {
-            // begin-snippet: assert_text_before
+            // begin-snippet: assert_text_arrays
             var header = new Header();
-            var actual = header.MakeHeading("I am ten chars");
-            var expected = "";
+            var actual = header.MakeArrayHeading("I am a heading");
+            var expected = new[]{
+                "**************",
+                "I am a heading",
+                "**************",
+            };
             Approvals.AssertText(expected, actual);
             // end-snippet
         }
 
 
-
+        public void MakerheaderBefore()
+        {
+            // begin-snippet: assert_text_before
+            var header = new Header();
+            var actual = header.MakeHeading("I am a heading");
+            var expected = "";
+            Approvals.AssertText(expected, actual);
+            // end-snippet
+        }
     }
 
     public class Header
     {
-        public string MakeHeading(string iAmTenChars)
+        public string MakeHeading(string heading)
         {
-           return new[]
-           {
-               "**************",
-
-               "I am ten chars",
-               "**************",
-           }.JoinWith("\n");
+           return MakeArrayHeading(heading).JoinWith("\n");
         }
+        public string[] MakeArrayHeading(string heading)
+        {
+            return new[]
+            {
+               "**************",
+               "I am a heading",
+               "**************",
+           };
+        }
+
     }
 }

--- a/src/ApprovalTests/Approvals.cs
+++ b/src/ApprovalTests/Approvals.cs
@@ -302,6 +302,11 @@ namespace ApprovalTests
             return new FrontLoadedReporterDisposer(reporter);
         }
 
+        public static void AssertText(string[] expected, string[] actual, IApprovalFailureReporter reporter = null)
+        {
+            AssertText(expected.JoinWith("\n"), actual.JoinWith("\n"));
+        }
+
         public static void AssertText(string[] expected, string actual, IApprovalFailureReporter reporter = null)
         {
             AssertText(expected.JoinWith("\n"), actual);


### PR DESCRIPTION
## Description

- Adds an overload to `Approvals.AssertText` to support param `actual` to be both a string, or an array of string.
- update documentation
- cleanup tests
