### PR TITLE
Encoding.ASCII instead of UTF8

### DIFF
--- a/src/ApprovalTests/Writers/ApprovalTextWriter.cs
+++ b/src/ApprovalTests/Writers/ApprovalTextWriter.cs
@@ -34,7 +34,7 @@ namespace ApprovalTests
         public string WriteReceivedFile(string received)
         {
             Directory.CreateDirectory(Path.GetDirectoryName(received));
-            File.WriteAllText(received, Data, Encoding.UTF8);
+            File.WriteAllText(received, Data, Encoding.ASCII);
             return received;
         }
     }


### PR DESCRIPTION
Encoding.UTF8 result in UTF8-BOM encoded text file that could not be compared with UTF8 file without complaining in diff tool

