### PR TITLE
B Fix test assembly location resolution for package-reference style

### DIFF
--- a/src/ApprovalTests/Namers/AssemblyLocationNamer.cs
+++ b/src/ApprovalTests/Namers/AssemblyLocationNamer.cs
@@ -1,6 +1,5 @@
-﻿using System;
 using System.IO;
-using System.Reflection;
+using System.Linq;
 
 namespace ApprovalTests.Namers
 {
@@ -10,11 +9,11 @@ namespace ApprovalTests.Namers
         {
             get
             {
-                // CodeBase is used because the NUnit test runner is otherwise quirky
-                var codeBase = Assembly.GetExecutingAssembly().CodeBase;
-                var uri = new UriBuilder(codeBase);
-                var path = Uri.UnescapeDataString(uri.Path);
-                return Path.GetDirectoryName(path);
+                var currentTestCaller = Approvals.CurrentCaller.NonLambdaCallers
+                    .First(c =>
+                        c.Class.Namespace.StartsWith("ApprovalTests") == false &&
+                        c.Class.Namespace.StartsWith("ApprovalUtilities") == false);
+                return Path.GetDirectoryName(currentTestCaller.Class.Assembly.Location);
             }
         }
 


### PR DESCRIPTION
Pre-existing implementation does not work for package-reference style projects as the ApprovalTests DLLs are referenced from the nuget cache location. A logic change to traverse the call stack up to the first non-approval-tests caller fixes this issue. Further details - https://github.com/approvals/ApprovalTests.Net/issues/387