### PR TITLE
Mark SerializableTheory as obsolete

### DIFF
--- a/src/ApprovalTests.Tests/Core/SerializableExceptionsTest.cs
+++ b/src/ApprovalTests.Tests/Core/SerializableExceptionsTest.cs
@@ -1,6 +1,7 @@
-﻿using ApprovalTests.Core.Exceptions;
-using ApprovalTests.TheoryTests;
+﻿#if NET48
 
+using ApprovalTests.Core.Exceptions;
+using ApprovalTests.TheoryTests;
 [TestFixture]
 public class SerializableExceptionsTest
 {
@@ -17,3 +18,4 @@ public class SerializableExceptionsTest
     static void Verify(object o) =>
         SerializableTheory.Verify(o, Assert.AreEqual);
 }
+#endif

--- a/src/ApprovalTests/TheoryTests/SerializableTheory.cs
+++ b/src/ApprovalTests/TheoryTests/SerializableTheory.cs
@@ -2,6 +2,7 @@
 
 namespace ApprovalTests.TheoryTests;
 
+[Obsolete("https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md")]
 public static class SerializableTheory
 {
     public static void Verify(object original, Action<object, object> assertEqual)


### PR DESCRIPTION
https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md