### PR TITLE
Remove Microsoft.Win32.Registry package dependency

### DIFF
--- a/src/ApprovalTests/ApprovalTests.csproj
+++ b/src/ApprovalTests/ApprovalTests.csproj
@@ -15,7 +15,6 @@
     <PackageReference Include="DiffEngine" Version="15.2.0" />
     <PackageReference Include="EmptyFiles" Version="8.1.0" PrivateAssets="None" />
     <PackageReference Include="Fody" Version="6.8.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="Publicize.Fody" Version="1.8.0" PrivateAssets="All" />
     <PackageReference Include="Virtuosity.Fody" Version="3.1.1" PrivateAssets="All" />
     <PackageReference Include="TextCopy" Version="6.2.1" />


### PR DESCRIPTION
M.W32.Registry has been inbox on .NET Framework since forever and in modern .NET starting with .NET 6. There's no need for the package reference anymore.