### PR TITLE
Fody 6.9.2

### DIFF
--- a/src/ApprovalTests/ApprovalTests.csproj
+++ b/src/ApprovalTests/ApprovalTests.csproj
@@ -14,7 +14,7 @@
     <Compile Include="..\ApprovalUtilities\InternalsVisibleTo.cs" Link="InternalsVisibleTo.cs" />
     <PackageReference Include="DiffEngine" Version="15.4.0" />
     <PackageReference Include="EmptyFiles" Version="8.2.0" PrivateAssets="None" />
-    <PackageReference Include="Fody" Version="6.8.0" PrivateAssets="all" />
+    <PackageReference Include="Fody" Version="6.9.2" PrivateAssets="all" />
     <PackageReference Include="Publicize.Fody" Version="1.8.0" PrivateAssets="All" />
     <PackageReference Include="Virtuosity.Fody" Version="3.1.1" PrivateAssets="All" />
     <PackageReference Include="TextCopy" Version="6.2.1" />

--- a/src/ApprovalUtilities/ApprovalUtilities.csproj
+++ b/src/ApprovalUtilities/ApprovalUtilities.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Using Remove="System.Net.Http" />
-    <PackageReference Include="Fody" Version="6.8.0" PrivateAssets="all" />
+    <PackageReference Include="Fody" Version="6.9.2" PrivateAssets="all" />
     <PackageReference Include="Publicize.Fody" Version="1.8.0" PrivateAssets="All" />
     <PackageReference Include="System.Management" Version="8.0.0" />
     <PackageReference Include="Virtuosity.Fody" Version="3.1.1" PrivateAssets="All" />


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Upgrade Fody dependency to version 6.9.2 in ApprovalTests and ApprovalUtilities projects