### PR TITLE
remove Publicize.Fody

### DIFF
--- a/src/ApprovalTests/ApprovalTests.csproj
+++ b/src/ApprovalTests/ApprovalTests.csproj
@@ -15,7 +15,6 @@
     <PackageReference Include="DiffEngine" Version="15.4.0" />
     <PackageReference Include="EmptyFiles" Version="8.2.0" PrivateAssets="None" />
     <PackageReference Include="Fody" Version="6.9.2" PrivateAssets="all" />
-    <PackageReference Include="Publicize.Fody" Version="1.8.0" PrivateAssets="All" />
     <PackageReference Include="Virtuosity.Fody" Version="3.1.1" PrivateAssets="All" />
     <PackageReference Include="TextCopy" Version="6.2.1" />
     <ProjectReference Include="..\ApprovalUtilities\ApprovalUtilities.csproj" />

--- a/src/ApprovalTests/FodyWeavers.xml
+++ b/src/ApprovalTests/FodyWeavers.xml
@@ -1,4 +1,3 @@
 ﻿<Weavers GenerateXsd="false">
-  <Publicize />
   <Virtuosity />
 </Weavers>

--- a/src/ApprovalTests/FodyWeavers.xsd
+++ b/src/ApprovalTests/FodyWeavers.xsd
@@ -5,7 +5,6 @@
     <xs:complexType>
       <xs:all>
         <xs:element name="Virtuosity" minOccurs="0" maxOccurs="1" type="xs:anyType" />
-        <xs:element name="Publicize" minOccurs="0" maxOccurs="1" type="xs:anyType" />
         <xs:element name="Obsolete" minOccurs="0" maxOccurs="1" type="xs:anyType" />
       </xs:all>
       <xs:attribute name="VerifyAssembly" type="xs:boolean">

--- a/src/ApprovalUtilities.Tests/Reflection/HandlerListEntryTest.BecomeNullObjectWhenItemIsWrongType.approved.txt
+++ b/src/ApprovalUtilities.Tests/Reflection/HandlerListEntryTest.BecomeNullObjectWhenItemIsWrongType.approved.txt
@@ -3,5 +3,4 @@
 	Handler: NULL
 	Key: NULL
 	Next: NULL
-	ListEntryType: System.ComponentModel.EventHandlerList+ListEntry
 }

--- a/src/ApprovalUtilities.Tests/Reflection/HandlerListEntryTest.ProxyNonPublicMembers.approved.txt
+++ b/src/ApprovalUtilities.Tests/Reflection/HandlerListEntryTest.ProxyNonPublicMembers.approved.txt
@@ -7,8 +7,6 @@
 	Handler: System.EventHandler
 	Key: System.Object
 	Next: NULL
-	ListEntryType: System.ComponentModel.EventHandlerList+ListEntry
 }
 
-	ListEntryType: System.ComponentModel.EventHandlerList+ListEntry
 }

--- a/src/ApprovalUtilities.Tests/Reflection/HandlerListUtilitiesTest.EnumerateList.approved.txt
+++ b/src/ApprovalUtilities.Tests/Reflection/HandlerListUtilitiesTest.EnumerateList.approved.txt
@@ -7,10 +7,8 @@
 	Handler: System.EventHandler
 	Key: System.Object
 	Next: NULL
-	ListEntryType: System.ComponentModel.EventHandlerList+ListEntry
 }
 
-	ListEntryType: System.ComponentModel.EventHandlerList+ListEntry
 }
 
 [1] = HandlerListEntry
@@ -18,6 +16,5 @@
 	Handler: System.EventHandler
 	Key: System.Object
 	Next: NULL
-	ListEntryType: System.ComponentModel.EventHandlerList+ListEntry
 }
 

--- a/src/ApprovalUtilities.Tests/Reflection/HandlerListUtilitiesTest.GetListHead.approved.txt
+++ b/src/ApprovalUtilities.Tests/Reflection/HandlerListUtilitiesTest.GetListHead.approved.txt
@@ -7,8 +7,6 @@
 	Handler: System.EventHandler
 	Key: System.Object
 	Next: NULL
-	ListEntryType: System.ComponentModel.EventHandlerList+ListEntry
 }
 
-	ListEntryType: System.ComponentModel.EventHandlerList+ListEntry
 }

--- a/src/ApprovalUtilities/ApprovalUtilities.csproj
+++ b/src/ApprovalUtilities/ApprovalUtilities.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <Using Remove="System.Net.Http" />
     <PackageReference Include="Fody" Version="6.9.2" PrivateAssets="all" />
-    <PackageReference Include="Publicize.Fody" Version="1.8.0" PrivateAssets="All" />
     <PackageReference Include="System.Management" Version="8.0.0" />
     <PackageReference Include="Virtuosity.Fody" Version="3.1.1" PrivateAssets="All" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />

--- a/src/ApprovalUtilities/FodyWeavers.xml
+++ b/src/ApprovalUtilities/FodyWeavers.xml
@@ -1,4 +1,3 @@
 ﻿<Weavers GenerateXsd="false">
-  <Publicize />
   <Virtuosity />
 </Weavers>

--- a/src/ApprovalUtilities/FodyWeavers.xsd
+++ b/src/ApprovalUtilities/FodyWeavers.xsd
@@ -5,7 +5,6 @@
     <xs:complexType>
       <xs:all>
         <xs:element name="Virtuosity" minOccurs="0" maxOccurs="1" type="xs:anyType" />
-        <xs:element name="Publicize" minOccurs="0" maxOccurs="1" type="xs:anyType" />
         <xs:element name="Obsolete" minOccurs="0" maxOccurs="1" type="xs:anyType" />
       </xs:all>
       <xs:attribute name="VerifyAssembly" type="xs:boolean">


### PR DESCRIPTION
fixes #768

## Summary by Sourcery

Enhancements:
- Remove Publicize.Fody from the FodyWeavers configuration in ApprovalTests and ApprovalUtilities